### PR TITLE
perf: Implement dbUnit performance improvement plan (WI-01 - WI-27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Use the Maven wrapper (`./mvnw`) for all build operations.
 # Run integration tests against a specific database
 ./mvnw clean verify -Pderby-10-14
 ./mvnw clean verify -Ph2-1-4
-./mvnw clean verify -Phsqldb-1-8
+./mvnw clean verify -Phsqldb-2-7
 ./mvnw clean verify -Ppostgresql-16
 ./mvnw clean verify -Pmysql-9-20
 ./mvnw clean verify -Pmssql-2022
@@ -146,8 +146,8 @@ Integration tests use `DatabaseEnvironment` to bootstrap the target database fro
 - Commit Messages:
   - Adhere strictly to de facto standard Git commit message formatting.
   - Use Conventional Commits format.
-  - **Commit Types:** `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`
-  - **Scopes:** any of the database names, `assertion`, `pom`, `log`, `docker`, `database`, `dataset`, `metadata`, `resultset`, `scripts`, `site`, `statement`
+  - **Commit Types:** `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`, `perf:`
+  - **Scopes:** any of the database names, `assertion`, `pom`, `log`, `docker`, `database`, `dataset`, `metadata`, `resultset`, `scripts`, `site`, `statement`, `search`
   - Capitalize the first word after the type and scope.
   - You may suggest additional CC commit types and scopes when encountering situations where the changes do not fit into the approved lists above.
   - Reference GitHub issues in the commit footer with `Refs: <issue-number>` (e.g. `Refs: 123`).  Do not use a # before the number.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -44,6 +44,9 @@
       <action dev="dependabot" type="update" due-to="Dependabot">Update maven dependency com.ibm.db2:jcc from 12.1.0.0 to 12.1.5.0 (#764).</action>
       <action dev="jeffjensen" type="update" issue="769" system="github" due-to="jeffjensen">
           Speed up per-cell column index lookups with an exact-case fast path in AbstractTableMetaData.
+      </action>
+      <action dev="jeffjensen" type="update" issue="770" system="github" due-to="jeffjensen">
+          Stop capturing stack traces in RowOutOfBoundsException end-of-rows control flow; the exception no longer carries a stack trace.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -98,6 +98,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="780" system="github" due-to="jeffjensen">
           Skip the timezone-suffix regex match in TimestampDataType.typeCast for strings that cannot possibly contain a timezone suffix.
+      </action>
+      <action dev="jeffjensen" type="update" issue="278" system="github" due-to="jeffjensen">
+          Guard hot-path debug logging in PreparedBatchStatement, SimplePreparedStatement, AutomaticPreparedBatchStatement, and InsertOperation.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -89,6 +89,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="779" system="github" due-to="jeffjensen">
           Detect columns without exception-based control flow in FlatXmlProducer.
+      </action>
+      <action dev="jeffjensen" type="fix" issue="767" system="github" due-to="jeffjensen">
+          Close result sets per iteration in PrimaryKeyFilter scans instead of leaking them.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -95,6 +95,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="768" system="github" due-to="jeffjensen">
           Release workbook cell style cache entries after XLS write, fixing a memory leak.
+      </action>
+      <action dev="jeffjensen" type="update" issue="780" system="github" due-to="jeffjensen">
+          Skip the timezone-suffix regex match in TimestampDataType.typeCast for strings that cannot possibly contain a timezone suffix.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -71,6 +71,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="491" system="github" due-to="jeffjensen">
           Replace quadratic table ordering in DatabaseSequenceFilter with a topological sort; ambiguous orders may differ but remain valid.
+      </action>
+      <action dev="jeffjensen" type="update" issue="617" system="github" due-to="jeffjensen">
+          Fetch result set column metadata once per table instead of once per column (DefaultMetadataHandler only).
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML output">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -47,6 +47,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="770" system="github" due-to="jeffjensen">
           Stop capturing stack traces in RowOutOfBoundsException end-of-rows control flow; the exception no longer carries a stack trace.
+      </action>
+      <action dev="jeffjensen" type="update" issue="771" system="github" due-to="jeffjensen">
+          Buffer XML output in XmlWriter; callers must close or flush the writer to guarantee complete output.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -92,6 +92,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="767" system="github" due-to="jeffjensen">
           Close result sets per iteration in PrimaryKeyFilter scans instead of leaking them.
+      </action>
+      <action dev="jeffjensen" type="fix" issue="768" system="github" due-to="jeffjensen">
+          Release workbook cell style cache entries after XLS write, fixing a memory leak.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -68,6 +68,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="491" system="github" due-to="jeffjensen">
           Cache dependency edges during DatabaseSequenceFilter sorting, eliminating repeated JDBC metadata queries.
+      </action>
+      <action dev="jeffjensen" type="update" issue="491" system="github" due-to="jeffjensen">
+          Replace quadratic table ordering in DatabaseSequenceFilter with a topological sort; ambiguous orders may differ but remain valid.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -62,6 +62,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="766" system="github" due-to="jeffjensen">
           Restore execution of DepthFirstSearch tests that silently stopped running under JUnit Jupiter.
+      </action>
+      <action dev="jeffjensen" type="fix" issue="766" system="github" due-to="jeffjensen">
+          Enforce the search depth limit in DepthFirstSearch; direct-dependency lookups no longer include transitive tables.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -113,6 +113,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="783" system="github" due-to="jeffjensen">
           Release each CSV row read by CsvProducer as soon as it is handed to the dataset consumer, instead of retaining the full parsed file in memory alongside the CachedDataSet being built from it.
+      </action>
+      <action dev="jeffjensen" type="update" issue="784" system="github" due-to="jeffjensen">
+          Replace the linear scan in OrderedTableNameMap.getOriginalTableName with a lookup map populated at add() time.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -80,6 +80,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="776" system="github" due-to="jeffjensen">
           Reduce per-cell overhead in the assertion comparison loop (hoisted row count, guarded debug logging).
+      </action>
+      <action dev="jeffjensen" type="update" issue="777" system="github" due-to="jeffjensen">
+          Reduce replacement scanning overhead in ReplacementTable.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -74,6 +74,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="617" system="github" due-to="jeffjensen">
           Fetch result set column metadata once per table instead of once per column (DefaultMetadataHandler only).
+      </action>
+      <action dev="jeffjensen" type="update" issue="775" system="github" due-to="jeffjensen">
+          Precompute sort keys in SortedTable instead of re-converting values on every comparison.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -56,6 +56,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="773" system="github" due-to="jeffjensen">
           Buffer DTD and YAML dataset output.
+      </action>
+      <action dev="jeffjensen" type="update" issue="774" system="github" due-to="jeffjensen">
+          Cache DecimalFormat instances per format string in XlsTable numeric cell reads.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -86,6 +86,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="778" system="github" due-to="jeffjensen">
           Flatten same-name table merging in CompositeDataSet from nested pairs to a single composite.
+      </action>
+      <action dev="jeffjensen" type="update" issue="779" system="github" due-to="jeffjensen">
+          Detect columns without exception-based control flow in FlatXmlProducer.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML output">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML and CSV output">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -50,6 +50,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="771" system="github" due-to="jeffjensen">
           Buffer XML output in XmlWriter; callers must close or flush the writer to guarantee complete output.
+      </action>
+      <action dev="jeffjensen" type="update" issue="772" system="github" due-to="jeffjensen">
+          Buffer CSV file output in CsvDataSetWriter.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names, primitive row index storage in RowFilterTable">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names, primitive row index storage in RowFilterTable, set-based membership in Columns.mergeColumnsByName">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -119,6 +119,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="785" system="github" due-to="jeffjensen">
           Store RowFilterTable's filtered row index mapping as a primitive int array instead of boxed Integer objects.
+      </action>
+      <action dev="jeffjensen" type="update" issue="786" system="github" due-to="jeffjensen">
+          Replace the O(n*m^2) nested scan and List.remove(Object) in Columns.mergeColumnsByName with set-based membership.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -83,6 +83,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="777" system="github" due-to="jeffjensen">
           Reduce replacement scanning overhead in ReplacementTable.
+      </action>
+      <action dev="jeffjensen" type="update" issue="778" system="github" due-to="jeffjensen">
+          Flatten same-name table merging in CompositeDataSet from nested pairs to a single composite.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -42,6 +42,9 @@
       <action dev="dependabot" type="update" due-to="Dependabot">Update maven dependency org.jacoco:jacoco-maven-plugin from 0.8.14 to 0.8.15 (#763).</action>
       <!-- dependabot:dep=com.ibm.db2:jcc:new=12.1.5.0:pr=764 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update maven dependency com.ibm.db2:jcc from 12.1.0.0 to 12.1.5.0 (#764).</action>
+      <action dev="jeffjensen" type="update" issue="769" system="github" due-to="jeffjensen">
+          Speed up per-cell column index lookups with an exact-case fast path in AbstractTableMetaData.
+      </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">
       <!-- dependabot:dep=actions/deploy-pages:new=5:pr=27 -->

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -59,6 +59,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="774" system="github" due-to="jeffjensen">
           Cache DecimalFormat instances per format string in XlsTable numeric cell reads.
+      </action>
+      <action dev="jeffjensen" type="fix" issue="766" system="github" due-to="jeffjensen">
+          Restore execution of DepthFirstSearch tests that silently stopped running under JUnit Jupiter.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -110,6 +110,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="788" system="github" due-to="jeffjensen">
           Close the internal file stream in the XlsDataSet(File) constructor instead of leaking it; buffer it while open.
+      </action>
+      <action dev="jeffjensen" type="update" issue="783" system="github" due-to="jeffjensen">
+          Release each CSV row read by CsvProducer as soon as it is handed to the dataset consumer, instead of retaining the full parsed file in memory alongside the CachedDataSet being built from it.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -101,6 +101,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="278" system="github" due-to="jeffjensen">
           Guard hot-path debug logging in PreparedBatchStatement, SimplePreparedStatement, AutomaticPreparedBatchStatement, and InsertOperation.
+      </action>
+      <action dev="jeffjensen" type="fix" issue="767" system="github" due-to="jeffjensen">
+          Close the result set in SQLHelper.getPrimaryKeyColumn and raise a clear SQLException when the table has no primary key.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -77,6 +77,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="775" system="github" due-to="jeffjensen">
           Precompute sort keys in SortedTable instead of re-converting values on every comparison.
+      </action>
+      <action dev="jeffjensen" type="update" issue="776" system="github" due-to="jeffjensen">
+          Reduce per-cell overhead in the assertion comparison loop (hoisted row count, guarded debug logging).
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -107,6 +107,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="781" system="github" due-to="jeffjensen">
           Reuse the cached table in QueryTableIterator.getTableMetaData instead of separately querying the database, also fixing a result set leak in the previous implementation.
+      </action>
+      <action dev="jeffjensen" type="fix" issue="788" system="github" due-to="jeffjensen">
+          Close the internal file stream in the XlsDataSet(File) constructor instead of leaking it; buffer it while open.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -65,6 +65,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="766" system="github" due-to="jeffjensen">
           Enforce the search depth limit in DepthFirstSearch; direct-dependency lookups no longer include transitive tables.
+      </action>
+      <action dev="jeffjensen" type="update" issue="491" system="github" due-to="jeffjensen">
+          Cache dependency edges during DatabaseSequenceFilter sorting, eliminating repeated JDBC metadata queries.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML and CSV output">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -53,6 +53,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="772" system="github" due-to="jeffjensen">
           Buffer CSV file output in CsvDataSetWriter.
+      </action>
+      <action dev="jeffjensen" type="update" issue="773" system="github" due-to="jeffjensen">
+          Buffer DTD and YAML dataset output.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names, primitive row index storage in RowFilterTable">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -116,6 +116,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="784" system="github" due-to="jeffjensen">
           Replace the linear scan in OrderedTableNameMap.getOriginalTableName with a lookup map populated at add() time.
+      </action>
+      <action dev="jeffjensen" type="update" issue="785" system="github" due-to="jeffjensen">
+          Store RowFilterTable's filtered row index mapping as a primitive int array instead of boxed Integer objects.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -104,6 +104,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="767" system="github" due-to="jeffjensen">
           Close the result set in SQLHelper.getPrimaryKeyColumn and raise a clear SQLException when the table has no primary key.
+      </action>
+      <action dev="jeffjensen" type="update" issue="781" system="github" due-to="jeffjensen">
+          Reuse the cached table in QueryTableIterator.getTableMetaData instead of separately querying the database, also fixing a result set leak in the previous implementation.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/main/java/org/dbunit/assertion/DbUnitAssertBase.java
+++ b/src/main/java/org/dbunit/assertion/DbUnitAssertBase.java
@@ -552,7 +552,8 @@ public class DbUnitAssertBase
                         expectedTableName);
 
         // iterate over all rows
-        for (int rowNum = 0; rowNum < expectedTable.getRowCount(); rowNum++)
+        final int rowCount = expectedTable.getRowCount();
+        for (int rowNum = 0; rowNum < rowCount; rowNum++)
         {
             // iterate over all columns of the current row
             final int columnCount = comparisonCols.length;
@@ -591,10 +592,13 @@ public class DbUnitAssertBase
             final ValueComparer valueComparer = determineValueComparer(
                     columnName, defaultValueComparer, columnValueComparers);
 
-            log.debug(
-                    "compareData: comparing actualValue={}"
-                            + " to expectedValue={} with valueComparer={}",
-                    actualValue, expectedValue, valueComparer);
+            if (log.isDebugEnabled())
+            {
+                log.debug(
+                        "compareData: comparing actualValue={}"
+                                + " to expectedValue={} with valueComparer={}",
+                        actualValue, expectedValue, valueComparer);
+            }
             final String failMessage =
                     valueComparer.compare(expectedTable, actualTable, rowNum,
                             columnName, dataType, expectedValue, actualValue);
@@ -627,11 +631,14 @@ public class DbUnitAssertBase
         ValueComparer valueComparer = columnValueComparers.get(columnName);
         if (valueComparer == null)
         {
-            log.debug(
-                    "determineValueComparer: using defaultValueComparer='{}'"
-                            + " as columnName='{}' not found"
-                            + " in columnValueComparers='{}'",
-                    defaultValueComparer, columnName, columnValueComparers);
+            if (log.isDebugEnabled())
+            {
+                log.debug(
+                        "determineValueComparer: using defaultValueComparer='{}'"
+                                + " as columnName='{}' not found"
+                                + " in columnValueComparers='{}'",
+                        defaultValueComparer, columnName, columnValueComparers);
+            }
             valueComparer = defaultValueComparer;
         }
 

--- a/src/main/java/org/dbunit/assertion/comparer/value/ValueComparerBase.java
+++ b/src/main/java/org/dbunit/assertion/comparer/value/ValueComparerBase.java
@@ -40,10 +40,14 @@ public abstract class ValueComparerBase implements ValueComparer
         failMessage = doCompare(expectedTable, actualTable, rowNum, columnName,
                 dataType, expectedValue, actualValue);
 
-        log.debug(
-                "compare: rowNum={}, columnName={}, expectedValue={},"
-                        + " actualValue={}, failMessage={}",
-                rowNum, columnName, expectedValue, actualValue, failMessage);
+        if (log.isDebugEnabled())
+        {
+            log.debug(
+                    "compare: rowNum={}, columnName={}, expectedValue={},"
+                            + " actualValue={}, failMessage={}",
+                    rowNum, columnName, expectedValue, actualValue,
+                    failMessage);
+        }
 
         return failMessage;
     }

--- a/src/main/java/org/dbunit/database/DatabaseSequenceFilter.java
+++ b/src/main/java/org/dbunit/database/DatabaseSequenceFilter.java
@@ -21,16 +21,14 @@
 package org.dbunit.database;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.dbunit.database.search.ExportedKeysSearchCallback;
 import org.dbunit.database.search.ImportedKeysSearchCallback;
@@ -123,75 +121,94 @@ public class DatabaseSequenceFilter extends SequenceTableFilter
             info.checkCycles();
         }
 
-        return sort(tableNames, dependencies);
+        try {
+            return sort(connection, tableNames, dependencies);
+        } catch (SearchException e) {
+            throw new DataSetException("Exception while searching the dependent tables.", e);
+        }
     }
 
 
-    private static String[] sort(String[] tableNames, Map dependencies)
+    /**
+     * Topologically sorts {@code tableNames} via Kahn's algorithm, using each table's direct
+     * dependency info: an edge runs from a table to each of its direct dependents (the tables
+     * in its {@link DependencyInfo#getDirectDependentTablesSet()}), meaning the table must
+     * precede those dependents in the result. Cycles are assumed already rejected by
+     * {@link DependencyInfo#checkCycles()}, called earlier in {@link #sortTableNames}.
+     * @param connection The database connection used to resolve the stored identifier case.
+     * @param tableNames The table names to be ordered.
+     * @param dependencies Each table name's {@link DependencyInfo}, keyed by table name.
+     * @return The topologically sorted table names; when more than one valid order exists,
+     * ties break to the original {@code tableNames} order.
+     * @throws SearchException If the JDBC connection cannot be obtained.
+     */
+    private static String[] sort(IDatabaseConnection connection, String[] tableNames, Map dependencies)
+    throws SearchException
     {
         logger.debug("sort(tableNames={}, dependencies={}) - start", tableNames, dependencies);
 
-        boolean reprocess = true;
-        List tmpTableNames = Arrays.asList(tableNames);
-        List sortedTableNames = null;
+        int tableCount = tableNames.length;
+        // Dependency-set entries (below) come back in the database's native identifier case
+        // (e.g. lowercase on PostgreSQL), which can differ from the caller-supplied tableNames
+        // case; index by that same normalized case so the edge lookups below actually match.
+        String[] normalizedNames = normalizeToStoredCase(connection, tableNames);
+        Map<String, Integer> nameToIndex = new HashMap<String, Integer>(tableCount);
+        for (int i = 0; i < tableCount; i++)
+        {
+            nameToIndex.put(normalizedNames[i], i);
+        }
 
-        while (reprocess) {
-            sortedTableNames = new LinkedList();
-
-            // re-order 'tmpTableNames' into 'sortedTableNames'
-            for (Iterator i = tmpTableNames.iterator(); i.hasNext();)
+        // In-degree = how many of this table's direct dependencies (prerequisites), among the
+        // tables being sorted, have not yet been placed in the result.
+        int[] inDegree = new int[tableCount];
+        for (int i = 0; i < tableCount; i++)
+        {
+            DependencyInfo info = (DependencyInfo) dependencies.get(tableNames[i]);
+            for (Iterator it = info.getDirectDependsOnTablesSet().iterator(); it.hasNext();)
             {
-                boolean foundDependentInSortedTableNames = false;
-                String tmpTable = (String)i.next();
-                DependencyInfo tmpTableDependents = (DependencyInfo) dependencies.get(tmpTable);
-                
-
-                int sortedTableIndex = -1;
-                for (Iterator k = sortedTableNames.iterator(); k.hasNext();)
+                if (nameToIndex.containsKey(it.next()))
                 {
-                    String sortedTable = (String)k.next();
-                    if (tmpTableDependents.containsDirectDependsOn(sortedTable))
+                    inDegree[i]++;
+                }
+            }
+        }
+
+        // Indices (not names) of tables with no remaining prerequisites. A TreeSet always
+        // yields the smallest index first, so whenever several tables become ready at once,
+        // the one appearing earliest in the original tableNames order is emitted first.
+        TreeSet<Integer> ready = new TreeSet<Integer>();
+        for (int i = 0; i < tableCount; i++)
+        {
+            if (inDegree[i] == 0)
+            {
+                ready.add(i);
+            }
+        }
+
+        String[] sortedTableNames = new String[tableCount];
+        int sortedCount = 0;
+        while (!ready.isEmpty())
+        {
+            int index = ready.pollFirst();
+            String tableName = tableNames[index];
+            sortedTableNames[sortedCount++] = tableName;
+
+            DependencyInfo info = (DependencyInfo) dependencies.get(tableName);
+            for (Iterator it = info.getDirectDependentTablesSet().iterator(); it.hasNext();)
+            {
+                Integer dependentIndex = nameToIndex.get(it.next());
+                if (dependentIndex != null)
+                {
+                    inDegree[dependentIndex]--;
+                    if (inDegree[dependentIndex] == 0)
                     {
-                        sortedTableIndex = sortedTableNames.indexOf(sortedTable);
-                        foundDependentInSortedTableNames = true;
-                        break; // end for loop; we know the index
+                        ready.add(dependentIndex);
                     }
                 }
+            }
+        }
 
-                
-                // add 'tmpTable' to 'sortedTableNames'.
-                // Insert it before its first dependent if there are any,
-                // otherwise append it to the end of 'sortedTableNames'
-                if (foundDependentInSortedTableNames) {
-                    if (sortedTableIndex < 0) {
-                        throw new IllegalStateException(
-                            "sortedTableIndex should be 0 or greater, but is "
-                                + sortedTableIndex);
-                    }
-                    sortedTableNames.add(sortedTableIndex, tmpTable);
-                }
-                else
-                {
-                    sortedTableNames.add(tmpTable);
-                }
-            }
-            
-            
-            
-            // don't stop processing until we have a perfect run (no re-ordering)
-            if (tmpTableNames.equals(sortedTableNames))
-            {
-                reprocess = false;
-            }
-            else
-            {
-
-                tmpTableNames = null;
-                tmpTableNames = (List)((LinkedList)sortedTableNames).clone();
-            }
-        }// end 'while (reprocess)'
-        
-        return (String[])sortedTableNames.toArray(new String[0]);
+        return sortedTableNames;
     }
 
     /**
@@ -357,13 +374,6 @@ public class DatabaseSequenceFilter extends SequenceTableFilter
             this.allTableDependsOn = allTableDependsOn;
             this.allTableDependent = allTableDependent;
             this.tableName = tableName;
-        }
-
-        public boolean containsDirectDependent(String tableName) {
-            return this.directDependentTablesSet.contains(tableName);
-        }
-        public boolean containsDirectDependsOn(String tableName) {
-            return this.directDependsOnTablesSet.contains(tableName);
         }
 
         public String getTableName() {

--- a/src/main/java/org/dbunit/database/DatabaseSequenceFilter.java
+++ b/src/main/java/org/dbunit/database/DatabaseSequenceFilter.java
@@ -27,12 +27,17 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
-import org.dbunit.database.search.TablesDependencyHelper;
+import org.dbunit.database.search.ExportedKeysSearchCallback;
+import org.dbunit.database.search.ImportedKeysSearchCallback;
 import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.filter.SequenceTableFilter;
+import org.dbunit.util.search.DepthFirstSearch;
+import org.dbunit.util.search.ISearchCallback;
 import org.dbunit.util.search.SearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,10 +100,16 @@ public class DatabaseSequenceFilter extends SequenceTableFilter
 
         // Get dependencies for each table
         Map dependencies = new HashMap();
+        // Per-invocation edge caches, shared across all tables below, so that a node
+        // visited by more than one table's search (or by both its direct and transitive
+        // searches) only ever triggers one getImportedKeys/getExportedKeys JDBC round trip.
+        Map importedEdgesCache = new HashMap();
+        Map exportedEdgesCache = new HashMap();
         try {
             for (int i = 0; i < tableNames.length; i++) {
                 String tableName = tableNames[i];
-                DependencyInfo info = getDependencyInfo(connection, tableName);
+                DependencyInfo info = getDependencyInfo(connection, tableName,
+                        importedEdgesCache, exportedEdgesCache);
                 dependencies.put(tableName, info);
             }
         } catch (SearchException e) {
@@ -111,22 +122,22 @@ public class DatabaseSequenceFilter extends SequenceTableFilter
             DependencyInfo info = (DependencyInfo) iterator.next();
             info.checkCycles();
         }
-        
+
         return sort(tableNames, dependencies);
     }
-    
 
-    private static String[] sort(String[] tableNames, Map dependencies) 
+
+    private static String[] sort(String[] tableNames, Map dependencies)
     {
         logger.debug("sort(tableNames={}, dependencies={}) - start", tableNames, dependencies);
-        
+
         boolean reprocess = true;
         List tmpTableNames = Arrays.asList(tableNames);
         List sortedTableNames = null;
-        
+
         while (reprocess) {
             sortedTableNames = new LinkedList();
-            
+
             // re-order 'tmpTableNames' into 'sortedTableNames'
             for (Iterator i = tmpTableNames.iterator(); i.hasNext();)
             {
@@ -184,37 +195,126 @@ public class DatabaseSequenceFilter extends SequenceTableFilter
     }
 
     /**
-     * Creates the dependency information for the given table
-     * @param connection
-     * @param tableName
-     * @return The dependency information for the given table
-     * @throws SearchException
+     * Creates the dependency information for the given table.
+     * @param connection The database connection used to resolve foreign-key metadata.
+     * @param tableName The table name for which to compute dependency information.
+     * @param importedEdgesCache Per-{@code sortTableNames}-invocation cache of {@code ImportedKeysSearchCallback}
+     * edges, shared across all tables being sorted; keyed by table name.
+     * @param exportedEdgesCache Same as {@code importedEdgesCache}, for {@code ExportedKeysSearchCallback} edges.
+     * @return The dependency information for the given table.
+     * @throws SearchException If the JDBC connection cannot be obtained.
      */
     private static DependencyInfo getDependencyInfo(
-            IDatabaseConnection connection, String tableName) 
-    throws SearchException 
+            IDatabaseConnection connection, String tableName,
+            Map importedEdgesCache, Map exportedEdgesCache)
+    throws SearchException
     {
         logger.debug("getDependencyInfo(connection={}, tableName={}) - start", connection, tableName);
-        
-        // The tables dependency helpers makes a depth search for dependencies and returns the whole
-        // tree of dependent objects, not only the direct FK-PK related tables.
-        String[] allDependentTables = TablesDependencyHelper.getDependentTables(connection, tableName);
-        String[] allDependsOnTables = TablesDependencyHelper.getDependsOnTables(connection, tableName);
-        Set allDependentTablesSet = new HashSet(Arrays.asList(allDependentTables));
-        Set allDependsOnTablesSet = new HashSet(Arrays.asList(allDependsOnTables));
-        // Remove the table itself which is automatically included by the TablesDependencyHelper
-        allDependentTablesSet.remove(tableName);
-        allDependsOnTablesSet.remove(tableName);
-        
-        Set directDependsOnTablesSet = TablesDependencyHelper.getDirectDependsOnTables(connection, tableName);
-        Set directDependentTablesSet = TablesDependencyHelper.getDirectDependentTables(connection, tableName);
-        directDependsOnTablesSet.remove(tableName);
-        directDependentTablesSet.remove(tableName);
-        
-        DependencyInfo info = new DependencyInfo(tableName, 
-                directDependsOnTablesSet, directDependentTablesSet, 
+
+        // Equivalent to TablesDependencyHelper.getDependentTables/getDependsOnTables/
+        // getDirectDependentTables/getDirectDependsOnTables, inlined here (rather than calling
+        // those methods) so the same callback instance -- and therefore the same edge cache --
+        // can be reused for both the direct and transitive searches below. Each does a depth
+        // search for dependencies; the unlimited ones return the whole tree of dependent
+        // objects, not only the direct FK-PK related tables.
+        ISearchCallback importedCallback = new CachingSearchCallback(
+                new ImportedKeysSearchCallback(connection), importedEdgesCache);
+        ISearchCallback exportedCallback = new CachingSearchCallback(
+                new ExportedKeysSearchCallback(connection), exportedEdgesCache);
+        String[] normalizedRoot = normalizeToStoredCase(connection, new String[] {tableName});
+
+        Set allDependsOnTablesSet = new DepthFirstSearch().search(normalizedRoot, importedCallback);
+        Set allDependentTablesSet = new DepthFirstSearch().search(normalizedRoot, exportedCallback);
+        // Remove the table itself which is automatically included by the search
+        allDependentTablesSet.remove(normalizedRoot[0]);
+        allDependsOnTablesSet.remove(normalizedRoot[0]);
+
+        // Computed after the unlimited searches above: the root's edges (and, for the
+        // exported-keys direction, its direct dependents' edges too) are already cached by
+        // then, so these two calls are cache hits, not additional JDBC round trips.
+        Set directDependsOnTablesSet = new DepthFirstSearch(1).search(normalizedRoot, importedCallback);
+        Set directDependentTablesSet = new DepthFirstSearch(1).search(normalizedRoot, exportedCallback);
+        directDependsOnTablesSet.remove(normalizedRoot[0]);
+        directDependentTablesSet.remove(normalizedRoot[0]);
+
+        DependencyInfo info = new DependencyInfo(tableName,
+                directDependsOnTablesSet, directDependentTablesSet,
                 allDependsOnTablesSet, allDependentTablesSet);
         return info;
+    }
+
+    /**
+     * Lowercases the given table names when the database stores unquoted identifiers in
+     * lowercase (e.g. PostgreSQL), so that {@link DepthFirstSearch}'s visited-node set stays
+     * consistent with the lowercase FK-metadata names returned by the driver. Mirrors
+     * {@code TablesDependencyHelper.normalizeToStoredCase}, duplicated here (rather than reused)
+     * since it is private there and this class no longer calls through the helper's per-search
+     * factory methods -- doing so would prevent the callback (and therefore its edge cache) from
+     * being shared between the direct and transitive searches for the same table.
+     * @param connection The database connection used to determine stored identifier case.
+     * @param tableNames The table names to normalize.
+     * @return The table names lowercased if needed, otherwise the original array.
+     * @throws SearchException If the JDBC connection cannot be obtained.
+     */
+    private static String[] normalizeToStoredCase(IDatabaseConnection connection, String[] tableNames)
+    throws SearchException
+    {
+        try
+        {
+            if (!connection.getConnection().getMetaData().storesLowerCaseIdentifiers())
+            {
+                return tableNames;
+            }
+            String[] normalized = new String[tableNames.length];
+            for (int i = 0; i < tableNames.length; i++)
+            {
+                normalized[i] = tableNames[i].toLowerCase(Locale.ENGLISH);
+            }
+            return normalized;
+        }
+        catch (SQLException e)
+        {
+            throw new SearchException(e);
+        }
+    }
+
+    /**
+     * {@link ISearchCallback} decorator that memoizes {@link #getEdges(Object)} results in a
+     * shared map, so repeated visits to the same node -- across the direct and transitive
+     * searches for one table, and across different tables within one {@code sortTableNames}
+     * invocation -- reuse the previously fetched JDBC metadata instead of re-querying it.
+     */
+    private static class CachingSearchCallback implements ISearchCallback
+    {
+        private final ISearchCallback delegate;
+        private final Map edgesCache;
+
+        CachingSearchCallback(ISearchCallback delegate, Map edgesCache)
+        {
+            this.delegate = delegate;
+            this.edgesCache = edgesCache;
+        }
+
+        public SortedSet getEdges(Object fromNode) throws SearchException
+        {
+            if (edgesCache.containsKey(fromNode))
+            {
+                return (SortedSet) edgesCache.get(fromNode);
+            }
+            SortedSet edges = delegate.getEdges(fromNode);
+            edgesCache.put(fromNode, edges);
+            return edges;
+        }
+
+        public void nodeAdded(Object fromNode) throws SearchException
+        {
+            delegate.nodeAdded(fromNode);
+        }
+
+        public boolean searchNode(Object node) throws SearchException
+        {
+            return delegate.searchNode(node);
+        }
     }
 
 

--- a/src/main/java/org/dbunit/database/PrimaryKeyFilter.java
+++ b/src/main/java/org/dbunit/database/PrimaryKeyFilter.java
@@ -244,7 +244,6 @@ public class PrimaryKeyFilter extends AbstractTableFilter {
     private void scanPKs(String table, String sql, Set allowedIds, List fkTables) throws SQLException
     {
         PreparedStatement pstmt = null;
-        ResultSet rs = null;
         try {
             pstmt = this.connection.getConnection().prepareStatement( sql );
             for(Iterator iterator = allowedIds.iterator(); iterator.hasNext(); ) {
@@ -253,17 +252,19 @@ public class PrimaryKeyFilter extends AbstractTableFilter {
                     this.logger.debug("Executing sql for ? = " + pk );
                 }
                 pstmt.setObject( 1, pk );
-                rs = pstmt.executeQuery();
-                while( rs.next() ) {
-                    for( int i=0; i<fkTables.size(); i++ ) {
-                        String newTable = (String) fkTables.get(i);
-                        Object fk = rs.getObject(i+1);
-                        if( fk != null ) {
-                            logger.debug("New ID: {}->{}", newTable, fk);
-                            addPKToScan( newTable, fk );
-                        } 
-                        else {
-                            logger.warn( "Found null FK for relationship {} =>{}", table, newTable );
+                try (ResultSet rs = pstmt.executeQuery())
+                {
+                    while( rs.next() ) {
+                        for( int i=0; i<fkTables.size(); i++ ) {
+                            String newTable = (String) fkTables.get(i);
+                            Object fk = rs.getObject(i+1);
+                            if( fk != null ) {
+                                logger.debug("New ID: {}->{}", newTable, fk);
+                                addPKToScan( newTable, fk );
+                            }
+                            else {
+                                logger.warn( "Found null FK for relationship {} =>{}", table, newTable );
+                            }
                         }
                     }
                 }
@@ -273,7 +274,7 @@ public class PrimaryKeyFilter extends AbstractTableFilter {
         }
         finally {
             // new in the finally block. has been in the catch only before
-            SQLHelper.close( rs, pstmt );
+            SQLHelper.close( pstmt );
         }
     }
 
@@ -304,7 +305,6 @@ public class PrimaryKeyFilter extends AbstractTableFilter {
         String sql = "SELECT " + pkColumn + " FROM " + fkTable + " WHERE " + fkColumn + " = ? ";
 
         PreparedStatement pstmt = null;
-        ResultSet rs = null;
         try {
             logger.debug("Preparing SQL query '{}'", sql);
 
@@ -315,14 +315,16 @@ public class PrimaryKeyFilter extends AbstractTableFilter {
                     this.logger.debug( "executing query '" + sql + "' for ? = " + pk );
                 }
                 pstmt.setObject( 1, pk );
-                rs = pstmt.executeQuery();
-                while( rs.next() ) {
-                    Object fk = rs.getObject(1);
-                    addPKToScan( fkTable, fk );
+                try (ResultSet rs = pstmt.executeQuery())
+                {
+                    while( rs.next() ) {
+                        Object fk = rs.getObject(1);
+                        addPKToScan( fkTable, fk );
+                    }
                 }
-            } 
+            }
         } finally {
-            SQLHelper.close( rs, pstmt );
+            SQLHelper.close( pstmt );
         }
     }
 

--- a/src/main/java/org/dbunit/database/QueryTableIterator.java
+++ b/src/main/java/org/dbunit/database/QueryTableIterator.java
@@ -111,25 +111,7 @@ public class QueryTableIterator implements ITableIterator
     {
         logger.debug("getTableMetaData() - start");
 
-        QueryDataSet.TableEntry entry = (QueryDataSet.TableEntry)_tableEntries.get(_index);
-
-        // No query specified, use metadata from dataset
-        if (entry.getQuery() == null)
-        {
-            try
-            {
-                ITable table = _connection.createTable(entry.getTableName());
-                return table.getTableMetaData();
-            }
-            catch (SQLException e)
-            {
-                throw new DataSetException(e);
-            }
-        }
-        else
-        {
-            return getTable().getTableMetaData();
-        }
+        return getTable().getTableMetaData();
     }
 
     /**

--- a/src/main/java/org/dbunit/database/ResultSetTableMetaData.java
+++ b/src/main/java/org/dbunit/database/ResultSetTableMetaData.java
@@ -25,6 +25,13 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.dbunit.dataset.AbstractTableMetaData;
 import org.dbunit.dataset.Column;
@@ -141,18 +148,27 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
 
     	Connection connection = resultSet.getStatement().getConnection();
     	DatabaseMetaData databaseMetaData = connection.getMetaData();
-    	
+
         ResultSetMetaData metaData = resultSet.getMetaData();
         Column[] columns = new Column[metaData.getColumnCount()];
+        // Fast-path cache of one getColumns() result per distinct (schema, table) origin, so a
+        // multi-column table is not re-queried once per column. Only safe for the exact
+        // DefaultMetadataHandler class (not instanceof: e.g. Db2MetadataHandler extends it but
+        // overrides matches() with DB2-specific catalog handling that this cache bypasses) --
+        // custom/ext handlers keep the legacy per-column path below.
+        Map columnsByOrigin = columnFactory.getClass() == DefaultMetadataHandler.class
+                ? new HashMap()
+                : null;
         for (int i = 0; i < columns.length; i++)
         {
             int rsIndex = i+1;
-            
+
             // 1. try to create the column from the DatabaseMetaData object. The DatabaseMetaData
             // provides more information and is more precise so that it should always be used in
             // preference to the ResultSetMetaData object.
-            columns[i] = createColumnFromDbMetaData(metaData, rsIndex, databaseMetaData, dataTypeFactory, columnFactory);
-            
+            columns[i] = createColumnFromDbMetaData(metaData, rsIndex, databaseMetaData, dataTypeFactory,
+                    columnFactory, columnsByOrigin);
+
             // 2. If we could not create the Column from a DatabaseMetaData object, try to create it
             // from the ResultSetMetaData object directly
             if(columns[i] == null)
@@ -204,36 +220,39 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
      * information about the column if possible
      * @param dataTypeFactory dbunit {@link IDataTypeFactory} needed to create the Column
      * @param metadataHandler the handler to be used for {@link DatabaseMetaData} handling
-     * @return The column or <code>null</code> if it can be not created using a 
-     * {@link DatabaseMetaData} object because of missing information in the 
+     * @param columnsByOrigin Fast-path cache of one getColumns() result per (schema, table)
+     * origin, or <code>null</code> to always use the legacy per-column lookup (see
+     * {@link #createMetaData(String, ResultSet, IDataTypeFactory, IMetadataHandler)}).
+     * @return The column or <code>null</code> if it can be not created using a
+     * {@link DatabaseMetaData} object because of missing information in the
      * {@link ResultSetMetaData} object
      * @throws SQLException
-     * @throws DataTypeException 
+     * @throws DataTypeException
      */
-    private Column createColumnFromDbMetaData(ResultSetMetaData rsMetaData, int rsIndex, 
+    private Column createColumnFromDbMetaData(ResultSetMetaData rsMetaData, int rsIndex,
             DatabaseMetaData databaseMetaData, IDataTypeFactory dataTypeFactory,
-            IMetadataHandler metadataHandler) 
-    throws SQLException, DataTypeException 
+            IMetadataHandler metadataHandler, Map columnsByOrigin)
+    throws SQLException, DataTypeException
     {
         if(logger.isTraceEnabled()){
-            logger.trace("createColumnFromMetaData(rsMetaData={}, rsIndex={}," + 
+            logger.trace("createColumnFromMetaData(rsMetaData={}, rsIndex={}," +
                     " databaseMetaData={}, dataTypeFactory={}, columnFactory={}) - start",
-                new Object[]{rsMetaData, String.valueOf(rsIndex), 
+                new Object[]{rsMetaData, String.valueOf(rsIndex),
                             databaseMetaData, dataTypeFactory, metadataHandler});
         }
-        
+
         // use DatabaseMetaData to retrieve the actual column definition
         String catalogName = rsMetaData.getCatalogName(rsIndex);
         String schemaName = rsMetaData.getSchemaName(rsIndex);
         String tableName = rsMetaData.getTableName(rsIndex);
         String columnName = rsMetaData.getColumnLabel(rsIndex);
-        
+
         // Due to a bug in the DB2 JDBC driver we have to trim the names
         catalogName = trim(catalogName);
         schemaName = trim(schemaName);
         tableName = trim(tableName);
         columnName = trim(columnName);
-        
+
         // Check if at least one of catalog/schema/table attributes is
         // not applicable (i.e. "" is returned). If so do not try
         // to get the column metadata from the DatabaseMetaData object.
@@ -252,14 +271,21 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
             "Will not try to lookup column properties via DatabaseMetaData.getColumns.");
             return null;
         }
-        
+
         if(logger.isDebugEnabled())
             logger.debug("All attributes from the ResultSetMetaData are valid, " +
                     "trying to lookup values in DatabaseMetaData. catalog={}, schema={}, table={}, column={}",
                     new Object[]{catalogName, schemaName, tableName, columnName} );
-        
-        // All of the retrieved attributes are valid, 
-        // so lookup the column via DatabaseMetaData
+
+        if (columnsByOrigin != null)
+        {
+            return createColumnFromCache(columnsByOrigin, databaseMetaData, metadataHandler,
+                    catalogName, schemaName, tableName, columnName, dataTypeFactory);
+        }
+
+        // Legacy path (custom/ext IMetadataHandler): fetch and linearly scan per column, since
+        // a custom handler's getColumns()/matches() overrides cannot be safely replayed against
+        // cached rows.
         ResultSet columnsResultSet = metadataHandler.getColumns(databaseMetaData, schemaName, tableName);
 
         try
@@ -281,6 +307,97 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
         {
             SQLHelper.close(columnsResultSet);
         }
+    }
+
+    /**
+     * Looks up a column's metadata from the per-(schema, table)-origin cache, lazily fetching
+     * and caching a whole table's columns (via a single {@code getColumns} call) on first need.
+     * Candidates are bucketed by {@link Locale#ENGLISH}-uppercased column name, then filtered by
+     * exact-case column name (only when {@link #_caseSensitiveMetaData} is set) and by catalog
+     * and table, using the same {@link SQLHelper#areEqualIgnoreNull(String, String, boolean)}
+     * semantics as the legacy {@code matches(...)} path -- a null/empty search catalog matches
+     * any row. The table check matters because {@code metadataHandler.getColumns} passes
+     * {@code tableName} to JDBC's {@code DatabaseMetaData#getColumns} as a LIKE pattern, not an
+     * exact match: a table name containing {@code _} or {@code %} (e.g. {@code USER_ACCOUNT})
+     * can make the driver also return columns from an unrelated, differently-named table whose
+     * name happens to match that pattern (e.g. {@code USERXACCOUNT}). The first remaining
+     * candidate, in {@code getColumns} row order, wins, consistent with a forward-scanning
+     * {@code scrollTo} match stopping at the first hit. A miss returns <code>null</code>, exactly
+     * like the not-found branch of the legacy per-column path.
+     */
+    private Column createColumnFromCache(Map columnsByOrigin, DatabaseMetaData databaseMetaData,
+            IMetadataHandler metadataHandler, String catalogName, String schemaName, String tableName,
+            String columnName, IDataTypeFactory dataTypeFactory)
+    throws SQLException, DataTypeException
+    {
+        String originKey = schemaName + '\0' + tableName;
+        Map columnsByName = (Map) columnsByOrigin.get(originKey);
+        if (columnsByName == null)
+        {
+            columnsByName = fetchColumnsByName(databaseMetaData, metadataHandler, schemaName, tableName);
+            columnsByOrigin.put(originKey, columnsByName);
+        }
+
+        List candidates = (List) columnsByName.get(columnName.toUpperCase(Locale.ENGLISH));
+        if (candidates == null)
+        {
+            return null;
+        }
+        for (Iterator it = candidates.iterator(); it.hasNext();)
+        {
+            ColumnMetaData data = (ColumnMetaData) it.next();
+            if (_caseSensitiveMetaData && !data.columnName.equals(columnName))
+            {
+                continue;
+            }
+            if (!SQLHelper.areEqualIgnoreNull(catalogName, data.catalogName, _caseSensitiveMetaData))
+            {
+                continue;
+            }
+            if (!SQLHelper.areEqualIgnoreNull(tableName, data.tableName, _caseSensitiveMetaData))
+            {
+                continue;
+            }
+            return data.toColumn(dataTypeFactory);
+        }
+        return null;
+    }
+
+    /**
+     * Fetches all columns for one (schema, table) origin in a single {@code getColumns} call and
+     * snapshots the fields {@link SQLHelper#createColumn} consumes, bucketed by
+     * {@link Locale#ENGLISH}-uppercased {@code COLUMN_NAME}. Rows are never dropped here (unlike
+     * the previous first-one-wins cache): when more than one row shares a column name -- e.g. the
+     * same schema/table existing in more than one catalog, since {@code getColumns} is invoked
+     * with a <code>null</code> catalog -- every candidate is kept so {@link #createColumnFromCache}
+     * can pick the one whose catalog (and, if case sensitive, exact-case name) actually matches.
+     */
+    private Map fetchColumnsByName(DatabaseMetaData databaseMetaData, IMetadataHandler metadataHandler,
+            String schemaName, String tableName)
+    throws SQLException
+    {
+        Map columnsByName = new HashMap();
+        ResultSet columnsResultSet = metadataHandler.getColumns(databaseMetaData, schemaName, tableName);
+        try
+        {
+            while (columnsResultSet.next())
+            {
+                ColumnMetaData data = ColumnMetaData.readFrom(columnsResultSet);
+                String key = data.columnName.toUpperCase(Locale.ENGLISH);
+                List candidates = (List) columnsByName.get(key);
+                if (candidates == null)
+                {
+                    candidates = new ArrayList();
+                    columnsByName.put(key, candidates);
+                }
+                candidates.add(data);
+            }
+        }
+        finally
+        {
+            SQLHelper.close(columnsResultSet);
+        }
+        return columnsByName;
     }
 
 
@@ -338,4 +455,87 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
 		sb.append("]");
 		return sb.toString();
 	}
+
+    /**
+     * Snapshot of the {@code DatabaseMetaData#getColumns} row fields that
+     * {@link SQLHelper#createColumn(ResultSet, IDataTypeFactory, boolean)} consumes, so a
+     * table's columns can be fetched once and converted to {@link Column} objects afterwards
+     * without re-querying per column.
+     */
+    private static final class ColumnMetaData
+    {
+        private final String catalogName;
+        private final String tableName;
+        private final String columnName;
+        private final int sqlType;
+        private final String sqlTypeName;
+        private final int nullable;
+        private final String remarks;
+        private final String columnDefaultValue;
+        private final String isAutoIncrement;
+        private final String isGenerated;
+
+        private ColumnMetaData(String catalogName, String tableName, String columnName, int sqlType,
+                String sqlTypeName, int nullable, String remarks, String columnDefaultValue,
+                String isAutoIncrement, String isGenerated)
+        {
+            this.catalogName = catalogName;
+            this.tableName = tableName;
+            this.columnName = columnName;
+            this.sqlType = sqlType;
+            this.sqlTypeName = sqlTypeName;
+            this.nullable = nullable;
+            this.remarks = remarks;
+            this.columnDefaultValue = columnDefaultValue;
+            this.isAutoIncrement = isAutoIncrement;
+            this.isGenerated = isGenerated;
+        }
+
+        /**
+         * Reads the same {@code getColumns} result set columns, by the same indexes, as
+         * {@link SQLHelper#createColumn(ResultSet, IDataTypeFactory, boolean)}, plus
+         * {@code TABLE_CAT} so cache candidates can be matched by catalog too.
+         */
+        private static ColumnMetaData readFrom(ResultSet resultSet) throws SQLException
+        {
+            String catalogName = resultSet.getString(1);
+            String tableName = resultSet.getString(3);
+            String columnName = resultSet.getString(4);
+            int sqlType = resultSet.getInt(5);
+            // If Types.DISTINCT like SQL DOMAIN, then get Source Date Type of SQL-DOMAIN
+            if(sqlType == Types.DISTINCT)
+            {
+                sqlType = resultSet.getInt("SOURCE_DATA_TYPE");
+            }
+            String sqlTypeName = resultSet.getString(6);
+            int nullable = resultSet.getInt(11);
+            String remarks = resultSet.getString(12);
+            String columnDefaultValue = resultSet.getString(13);
+            String isAutoIncrement = resultSet.getString(23);
+            // some JDBC drivers do not have this column even though they claim to be compliant with JDBC 4.1 or later
+            String isGenerated = resultSet.getMetaData().getColumnCount() >= 24 ? resultSet.getString(24) : null;
+            return new ColumnMetaData(catalogName, tableName, columnName, sqlType, sqlTypeName, nullable,
+                    remarks, columnDefaultValue, isAutoIncrement, isGenerated);
+        }
+
+        /**
+         * Mirrors {@link SQLHelper#createColumn(ResultSet, IDataTypeFactory, boolean)}'s
+         * construction (always with {@code datatypeWarning=true}, as {@code ResultSetTableMetaData}
+         * calls it), operating on these cached field values instead of a live result set row.
+         */
+        private Column toColumn(IDataTypeFactory dataTypeFactory) throws DataTypeException
+        {
+            DataType dataType = dataTypeFactory.createDataType(sqlType, sqlTypeName, tableName, columnName);
+            if (dataType == DataType.UNKNOWN)
+            {
+                logger.warn(tableName + "." + columnName +
+                        " data type (" + sqlType + ", '" + sqlTypeName +
+                        "') not recognized and will be ignored. See FAQ for more information.");
+                return null;
+            }
+            return new Column(columnName, dataType, sqlTypeName, Column.nullableValue(nullable),
+                    columnDefaultValue, remarks, Column.AutoIncrement.autoIncrementValue(isAutoIncrement),
+                    Column.convertMetaDataBoolean(isGenerated));
+        }
+    }
 }

--- a/src/main/java/org/dbunit/database/statement/AutomaticPreparedBatchStatement.java
+++ b/src/main/java/org/dbunit/database/statement/AutomaticPreparedBatchStatement.java
@@ -58,14 +58,20 @@ public class AutomaticPreparedBatchStatement implements IPreparedBatchStatement
     public void addValue(Object value, DataType dataType) throws TypeCastException,
             SQLException
     {
-        logger.debug("addValue(value={}, dataType={}) - start", value, dataType);
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("addValue(value={}, dataType={}) - start", value, dataType);
+        }
 
         _statement.addValue(value, dataType);
     }
 
     public void addBatch() throws SQLException
     {
-        logger.debug("addBatch() - start");
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("addBatch() - start");
+        }
 
         _statement.addBatch();
         _batchCount++;

--- a/src/main/java/org/dbunit/database/statement/PreparedBatchStatement.java
+++ b/src/main/java/org/dbunit/database/statement/PreparedBatchStatement.java
@@ -59,7 +59,10 @@ public class PreparedBatchStatement extends AbstractPreparedBatchStatement
     public void addValue(Object value, DataType dataType)
             throws TypeCastException, SQLException
     {
-        logger.debug("addValue(value={}, dataType={}) - start", value, dataType);
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("addValue(value={}, dataType={}) - start", value, dataType);
+        }
 
         // Special NULL handling
         if (value == null || value == ITable.NO_VALUE)

--- a/src/main/java/org/dbunit/database/statement/SimplePreparedStatement.java
+++ b/src/main/java/org/dbunit/database/statement/SimplePreparedStatement.java
@@ -61,7 +61,10 @@ public class SimplePreparedStatement extends AbstractPreparedBatchStatement
     public void addValue(Object value, DataType dataType)
             throws TypeCastException, SQLException
     {
-    	logger.debug("addValue(value={}, dataType={}) - start", value, dataType);
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("addValue(value={}, dataType={}) - start", value, dataType);
+        }
 
         // Special NULL handling
         if (value == null || value == ITable.NO_VALUE)

--- a/src/main/java/org/dbunit/dataset/AbstractTableMetaData.java
+++ b/src/main/java/org/dbunit/dataset/AbstractTableMetaData.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 import org.dbunit.DatabaseUnitRuntimeException;
@@ -46,8 +47,19 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractTableMetaData implements ITableMetaData
 {
 
-	private Map _columnsToIndexes;
-	
+	// volatile: _columnsToIndexes is the publication flag checked (unsynchronized) in
+	// getColumnIndex(); without it, the JMM permits a concurrent reader to observe this
+	// write before _exactColumnsToIndexes's, even though it is assigned second in program order.
+	private volatile Map _columnsToIndexes;
+
+	/**
+	 * Exact-case fast path for {@link #getColumnIndex(String)}, built alongside
+	 * {@link #_columnsToIndexes}. Only holds entries whose exact-case lookup agrees with
+	 * the uppercase-keyed lookup, so a hit here is always behavior-identical to the
+	 * uppercase path.
+	 */
+	private volatile Map<String, Integer> _exactColumnsToIndexes;
+
     /**
      * Logger for this class
      */
@@ -96,23 +108,35 @@ public abstract class AbstractTableMetaData implements ITableMetaData
 	 * @throws DataSetException 
 	 * @see org.dbunit.dataset.ITableMetaData#getColumnIndex(java.lang.String)
 	 */
-	public int getColumnIndex(String columnName) throws DataSetException 
+	public int getColumnIndex(String columnName) throws DataSetException
 	{
         logger.debug("getColumnIndex(columnName={}) - start", columnName);
 
-        if(this._columnsToIndexes == null) 
+        if(this._columnsToIndexes == null)
 		{
-			// lazily create the map
-			this._columnsToIndexes = createColumnIndexesMap(this.getColumns());
+			// lazily create the maps. _columnsToIndexes is the initialization flag checked
+			// above, so it must be published last: publishing it before _exactColumnsToIndexes
+			// is fully built would let a concurrent caller see this null-check pass and then
+			// NPE on a still-null _exactColumnsToIndexes below.
+			Column[] columns = this.getColumns();
+			Map colsToIndexes = createColumnIndexesMap(columns);
+			this._exactColumnsToIndexes = createExactColumnIndexesMap(columns, colsToIndexes);
+			this._columnsToIndexes = colsToIndexes;
 		}
-		
-        String columnNameUpperCase = columnName.toUpperCase();
+
+        Integer exactIndex = this._exactColumnsToIndexes.get(columnName);
+        if(exactIndex != null)
+        {
+            return exactIndex.intValue();
+        }
+
+        String columnNameUpperCase = columnName.toUpperCase(Locale.ENGLISH);
 		Integer colIndex = (Integer) this._columnsToIndexes.get(columnNameUpperCase);
 		if(colIndex != null)
 		{
 			return colIndex.intValue();
 		}
-		else 
+		else
 		{
 			throw new NoSuchColumnException(this.getTableName(), columnNameUpperCase,
 					" (Non-uppercase input column: " + columnName + ") in ColumnNameToIndexes cache map. " +
@@ -124,14 +148,39 @@ public abstract class AbstractTableMetaData implements ITableMetaData
 	 * @param columns The columns to be put into the hash table
 	 * @return A map having the key value pair [columnName, columnIndexInInputArray]
 	 */
-	private Map createColumnIndexesMap(Column[] columns) 
+	private Map createColumnIndexesMap(Column[] columns)
 	{
 		Map colsToIndexes = new HashMap(columns.length);
-		for (int i = 0; i < columns.length; i++) 
+		for (int i = 0; i < columns.length; i++)
 		{
-			colsToIndexes.put(columns[i].getColumnName().toUpperCase(), i);
+			colsToIndexes.put(columns[i].getColumnName().toUpperCase(Locale.ENGLISH), i);
 		}
 		return colsToIndexes;
+	}
+
+	/**
+	 * Builds the exact-case fast path map, keyed by the column's exact-case name.
+	 * A column is only included when its exact-case name resolves, via {@code colsToIndexes},
+	 * to the same index it occupies in the input array -- this is what makes an exact-map
+	 * hit behavior-identical to the uppercase path, even when duplicate case-insensitive
+	 * column names (e.g. "a" and "A") are present.
+	 * @param columns The columns to be put into the exact-case hash table.
+	 * @param colsToIndexes The fully-built uppercase columnName-to-index map to verify agreement against.
+	 * @return A map having the key value pair [exact-case columnName, columnIndexInInputArray].
+	 */
+	private Map<String, Integer> createExactColumnIndexesMap(Column[] columns, Map colsToIndexes)
+	{
+		Map<String, Integer> exactMap = new HashMap<String, Integer>(columns.length);
+		for (int i = 0; i < columns.length; i++)
+		{
+			String name = columns[i].getColumnName();
+			Integer upperIndex = (Integer) colsToIndexes.get(name.toUpperCase(Locale.ENGLISH));
+			if(upperIndex != null && upperIndex.intValue() == i)
+			{
+				exactMap.put(name, upperIndex);
+			}
+		}
+		return exactMap;
 	}
 
 	/**

--- a/src/main/java/org/dbunit/dataset/Columns.java
+++ b/src/main/java/org/dbunit/dataset/Columns.java
@@ -23,7 +23,9 @@ package org.dbunit.dataset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.dbunit.dataset.filter.IColumnFilter;
 import org.slf4j.Logger;
@@ -282,25 +284,19 @@ public class Columns
     public static Column[] mergeColumnsByName(Column[] referenceColumns, Column[] columnsToMerge) {
         logger.debug("mergeColumnsByName(referenceColumns={}, columnsToMerge={}) - start", referenceColumns, columnsToMerge);
 
-        List resultList = new ArrayList(Arrays.asList(referenceColumns));
-        List columnsToMergeNotInRefList = new ArrayList(Arrays.asList(columnsToMerge));
-        
-        // All columns that exist in the referenceColumns
+        Set referenceColumnNames = new HashSet();
         for (int i = 0; i < referenceColumns.length; i++) {
-            Column refColumn = referenceColumns[i];
-            for (int k = 0; k < columnsToMerge.length; k++) {
-                Column columnToMerge = columnsToMerge[k];
-                // Check if this colToMerge exists in the refColumn
-                if(columnToMerge.getColumnName().equals(refColumn.getColumnName())) {
-                    // We found the column in the refColumns - so no candidate for adding to the result list
-                    columnsToMergeNotInRefList.remove(columnToMerge);
-                    break;
-                }
+            referenceColumnNames.add(referenceColumns[i].getColumnName());
+        }
+
+        List resultList = new ArrayList(Arrays.asList(referenceColumns));
+        // Add each "columnsToMerge" entry that is not already present among the referenceColumns
+        for (int k = 0; k < columnsToMerge.length; k++) {
+            Column columnToMerge = columnsToMerge[k];
+            if (!referenceColumnNames.contains(columnToMerge.getColumnName())) {
+                resultList.add(columnToMerge);
             }
         }
-        
-        // Add all "columnsToMerge" that have not been found in the referenceColumnList
-        resultList.addAll(columnsToMergeNotInRefList);
         return (Column[]) resultList.toArray(new Column[]{});
     }
 

--- a/src/main/java/org/dbunit/dataset/CompositeDataSet.java
+++ b/src/main/java/org/dbunit/dataset/CompositeDataSet.java
@@ -21,6 +21,9 @@
 
 package org.dbunit.dataset;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dbunit.database.AmbiguousTableNameException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +97,7 @@ public class CompositeDataSet extends AbstractDataSet
                 addTable(iterator.getTable(), orderedTableMap, combine);
             }
         }
+        flattenCombinedTables(orderedTableMap);
 
         _tables = (ITable[]) orderedTableMap.orderedValues().toArray(new ITable[0]);
     }
@@ -179,6 +183,7 @@ public class CompositeDataSet extends AbstractDataSet
         {
             addTable(tables[i], orderedTableMap, true);
         }
+        flattenCombinedTables(orderedTableMap);
 
         _tables = (ITable[]) orderedTableMap.orderedValues().toArray(new ITable[0]);
     }
@@ -190,7 +195,7 @@ public class CompositeDataSet extends AbstractDataSet
      * @param combine
      * @throws AmbiguousTableNameException Can only occur when the combine flag is set to <code>false</code>.
      */
-    private void addTable(ITable newTable, OrderedTableNameMap tableMap, boolean combine) 
+    private void addTable(ITable newTable, OrderedTableNameMap tableMap, boolean combine)
     throws AmbiguousTableNameException
     {
     	if (logger.isDebugEnabled())
@@ -200,7 +205,7 @@ public class CompositeDataSet extends AbstractDataSet
     	}
 
         String tableName = newTable.getTableMetaData().getTableName();
-        
+
         // No merge required, simply add new table at then end of the list
         if (!combine)
         {
@@ -208,16 +213,55 @@ public class CompositeDataSet extends AbstractDataSet
             return;
         }
 
-        // Merge required, search for existing table with the same name
-        ITable existingTable = (ITable) tableMap.get(tableName);
-        if(existingTable != null) {
-            // Found existing table, merge existing and new tables together
-            tableMap.update(tableName, new CompositeTable(existingTable, newTable));
-            return;
+        // Merge required: accumulate same-name parts into a list, in encounter order.
+        // flattenCombinedTables() turns this into a single flat CompositeTable (or unwraps
+        // it if it turns out to have only one part) once every table has been seen --
+        // never the left-nested CompositeTable pairs a per-occurrence merge would produce.
+        List parts = (List) tableMap.get(tableName);
+        if (parts != null)
+        {
+            parts.add(newTable);
         }
-        else {
-            // No existing table found, add new table at the end of the list
-            tableMap.add(tableName, newTable);
+        else
+        {
+            parts = new ArrayList();
+            parts.add(newTable);
+            tableMap.add(tableName, parts);
+        }
+    }
+
+    /**
+     * Replaces each list of same-name table parts accumulated by {@link #addTable} with either
+     * the single part directly (if only one table used that name), or one flat {@link
+     * CompositeTable} wrapping all parts in encounter order -- matching the metadata and row
+     * ordering the old left-nested-pairs merge produced, without the O(parts) getRowCount()
+     * chain a nested CompositeTable.getValue would otherwise walk per access.
+     *
+     * @param tableMap The map being built by the constructor; entries not produced by a
+     * combine=true {@link #addTable} call (i.e. not a {@link List}) are left untouched.
+     */
+    private static void flattenCombinedTables(OrderedTableNameMap tableMap)
+    {
+        String[] tableNames = tableMap.getTableNames();
+        for (int i = 0; i < tableNames.length; i++)
+        {
+            String tableName = tableNames[i];
+            Object value = tableMap.get(tableName);
+            if (value instanceof List)
+            {
+                List parts = (List) value;
+                if (parts.size() == 1)
+                {
+                    tableMap.update(tableName, parts.get(0));
+                }
+                else
+                {
+                    ITable firstPart = (ITable) parts.get(0);
+                    ITable[] partsArray = (ITable[]) parts.toArray(new ITable[0]);
+                    tableMap.update(tableName,
+                            new CompositeTable(firstPart.getTableMetaData(), partsArray));
+                }
+            }
         }
     }
 

--- a/src/main/java/org/dbunit/dataset/CompositeTable.java
+++ b/src/main/java/org/dbunit/dataset/CompositeTable.java
@@ -91,6 +91,8 @@ public class CompositeTable extends AbstractTable {
     public int getRowCount() {
         logger.debug("getRowCount() - start");
 
+        // Not cached: the underlying tables (e.g. DefaultTable) are mutable and can grow
+        // after this CompositeTable is constructed, so a cached count could go stale.
         int totalCount = 0;
         for (int i = 0; i < _tables.length; i++) {
             ITable table = _tables[i];

--- a/src/main/java/org/dbunit/dataset/OrderedTableNameMap.java
+++ b/src/main/java/org/dbunit/dataset/OrderedTableNameMap.java
@@ -65,7 +65,14 @@ public class OrderedTableNameMap
 	 * which the table has been added
 	 */
 	private List _tableNames = new ArrayList();
-	
+
+	/**
+	 * Maps a case-normalized table name to the original-case name it was
+	 * added with, so {@link #getOriginalTableName(String)} can look it up
+	 * directly instead of scanning {@link #_tableNames}.
+	 */
+	private Map _originalTableNamesByNormalized = new HashMap();
+
 	private String _lastTableNameOverride;
 	
 	/**
@@ -200,6 +207,7 @@ public class OrderedTableNameMap
         else {
             this._tableMap.put(tableNameCorrectedCase, object);
             this._tableNames.add(tableName);
+            this._originalTableNamesByNormalized.put(tableNameCorrectedCase, tableName);
             // Reset the override of the lastTableName
             this._lastTableNameOverride = null;
         }
@@ -254,15 +262,8 @@ public class OrderedTableNameMap
     public String getOriginalTableName(String tableName)
     {
         String normalizedInput = getTableName(tableName);
-        for (Iterator it = _tableNames.iterator(); it.hasNext();)
-        {
-            String storedName = (String) it.next();
-            if (getTableName(storedName).equals(normalizedInput))
-            {
-                return storedName;
-            }
-        }
-        return tableName;
+        String originalName = (String) _originalTableNamesByNormalized.get(normalizedInput);
+        return originalName != null ? originalName : tableName;
     }
 
     /**

--- a/src/main/java/org/dbunit/dataset/ReplacementTable.java
+++ b/src/main/java/org/dbunit/dataset/ReplacementTable.java
@@ -134,28 +134,47 @@ public class ReplacementTable implements ITable
 
     /**
      * Replace occurrences of source in text with target. Operates directly on text.
+     * Searches text itself rather than a fresh text.toString() copy on every iteration.
      */
     private void replaceAll(StringBuilder text, String source, String target) {
+        if (source.length() == 0)
+        {
+            // An empty source matches at every position without ever advancing, so the loop
+            // below would never terminate.
+            return;
+        }
         int index = 0;
-        while((index = text.toString().indexOf(source, index)) != -1)
+        while((index = text.indexOf(source, index)) != -1)
         {
             text.replace(index, index+source.length(), target);
             index += target.length();
         }
     }
-    
+
     private String replaceStrings(String value, String lDelim, String rDelim) {
-        final StringBuilder buffer = new StringBuilder(value);
+        StringBuilder buffer = null;
 
         for (Iterator it = _substringMap.entrySet().iterator(); it.hasNext();)
         {
             Map.Entry entry = (Map.Entry)it.next();
             String original = (String)entry.getKey();
             String replacement = (String)entry.getValue();
-            replaceAll(buffer, lDelim + original + rDelim, replacement);
+            String source = lDelim + original + rDelim;
+
+            if (buffer == null)
+            {
+                // Materialize the StringBuilder only once a first hit occurs, so cells with
+                // no matching substring at all (the common case) allocate nothing.
+                if (value.indexOf(source) == -1)
+                {
+                    continue;
+                }
+                buffer = new StringBuilder(value);
+            }
+            replaceAll(buffer, source, replacement);
         }
 
-        return buffer == null ? value : buffer.toString();        
+        return buffer == null ? value : buffer.toString();
     }
     
     private String replaceSubstrings(String value)
@@ -246,10 +265,13 @@ public class ReplacementTable implements ITable
 
         Object value = _table.getValue(row, column);
 
-        // Object replacement
-        if (_objectMap.containsKey(value))
+        // Object replacement. A single get() covers the common case (a mapping with a
+        // non-null replacement); containsKey() is only needed to distinguish "no mapping"
+        // from "mapping to null" when get() itself returns null.
+        Object replacement = _objectMap.get(value);
+        if (replacement != null || _objectMap.containsKey(value))
         {
-            return _objectMap.get(value);
+            return replacement;
         }
 
         // Stop here if substring replacement not applicable

--- a/src/main/java/org/dbunit/dataset/RowFilterTable.java
+++ b/src/main/java/org/dbunit/dataset/RowFilterTable.java
@@ -46,8 +46,8 @@ public class RowFilterTable implements ITable, IRowValueProvider {
 	 * reference to the original table being wrapped 
 	 */
 	private final ITable originalTable;
-	/** mapping of filtered rows, i.e, each entry on this list has the value of 
-            the index on the original table corresponding to the desired index. 
+	/** mapping of filtered rows, i.e, each entry on this array has the value of
+            the index on the original table corresponding to the desired index.
             For instance, if the original table is:
             row   PK  Value
             0     pk1  v1
@@ -60,7 +60,7 @@ public class RowFilterTable implements ITable, IRowValueProvider {
             1     pk4  v4
             Consequently, the mapping will be {1, 3}
 	 */
-	private final List filteredRowIndexes;
+	private final int[] filteredRowIndexes;
 	/** 
 	 * logger 
 	 */
@@ -90,24 +90,29 @@ public class RowFilterTable implements ITable, IRowValueProvider {
 		this.filteredRowIndexes = setRows(rowFilter);
 	}
 
-	private List setRows(IRowFilter rowFilter) throws DataSetException {
+	private int[] setRows(IRowFilter rowFilter) throws DataSetException {
 
 		ITableMetaData tableMetadata = this.originalTable.getTableMetaData();
 		this.logger.debug("Setting rows for table {}",  tableMetadata.getTableName() );
 
 		int fullSize = this.originalTable.getRowCount();
-		List filteredRowIndexes = new ArrayList();
+		List matchedRowIndexes = new ArrayList();
 
 		for ( int row=0; row<fullSize; row++ ) {
 			this.currentRowIdx = row;
 			if(rowFilter.accept(this)) {
 				this.logger.debug("Adding row {}", row);
-				filteredRowIndexes.add(row);
+				matchedRowIndexes.add(row);
 			} else {
 				this.logger.debug("Discarding row {}", row);
 			}
 		}
-		return filteredRowIndexes;   
+
+		int[] filteredRowIndexes = new int[matchedRowIndexes.size()];
+		for ( int i=0; i<filteredRowIndexes.length; i++ ) {
+			filteredRowIndexes[i] = ((Integer) matchedRowIndexes.get(i)).intValue();
+		}
+		return filteredRowIndexes;
 	}
 
 
@@ -122,17 +127,17 @@ public class RowFilterTable implements ITable, IRowValueProvider {
 	public int getRowCount() {
 		logger.debug("getRowCount() - start");
 
-		return this.filteredRowIndexes.size();
+		return this.filteredRowIndexes.length;
 	}
 
-	public Object getValue(int row, String column) throws DataSetException 
+	public Object getValue(int row, String column) throws DataSetException
 	{
 	    if(logger.isDebugEnabled())
 	        logger.debug("getValue(row={}, columnName={}) - start", Integer.toString(row), column);
 
-		int max = this.filteredRowIndexes.size();
+		int max = this.filteredRowIndexes.length;
 		if ( row < max ) {
-			int realRow = ((Integer) this.filteredRowIndexes.get( row )).intValue();
+			int realRow = this.filteredRowIndexes[row];
 			Object value = this.originalTable.getValue(realRow, column);
 			return value;
 		} else {

--- a/src/main/java/org/dbunit/dataset/RowOutOfBoundsException.java
+++ b/src/main/java/org/dbunit/dataset/RowOutOfBoundsException.java
@@ -30,6 +30,11 @@ package org.dbunit.dataset;
 
 public class RowOutOfBoundsException extends DataSetException
 {
+    /** Matches the default (compiler-computed) value from dbunit 3.2.0, the last release
+     *  before {@link #fillInStackTrace()} was added; pinning it keeps this class
+     *  serialization-compatible with 3.2.0 and stable across all releases from here on. */
+    private static final long serialVersionUID = 3366609800061836144L;
+
     public RowOutOfBoundsException()
     {
     }
@@ -47,6 +52,18 @@ public class RowOutOfBoundsException extends DataSetException
     public RowOutOfBoundsException(Throwable e)
     {
         super(e);
+    }
+
+    /**
+     * Suppresses stack trace capture.
+     * This exception is thrown once per table scan as normal end-of-rows control flow,
+     * not as an error condition, so capturing a stack trace on every throw is wasted work.
+     * @return This exception, without a captured stack trace.
+     */
+    @Override
+    public synchronized Throwable fillInStackTrace()
+    {
+        return this;
     }
 }
 

--- a/src/main/java/org/dbunit/dataset/SortedTable.java
+++ b/src/main/java/org/dbunit/dataset/SortedTable.java
@@ -213,7 +213,8 @@ public class SortedTable extends AbstractTable
 
         if (_indexes == null)
         {
-            final Integer[] indexes = new Integer[getRowCount()];
+            final int rowCount = getRowCount();
+            final Integer[] indexes = new Integer[rowCount];
             for (int i = 0; i < indexes.length; i++)
             {
                 indexes[i] = i;
@@ -221,7 +222,11 @@ public class SortedTable extends AbstractTable
 
             try
             {
-                Arrays.sort(indexes, rowComparator);
+                final Comparator precomputedComparator =
+                        createPrecomputedKeyComparator(rowCount);
+                Arrays.sort(indexes,
+                        precomputedComparator != null ? precomputedComparator
+                                : rowComparator);
             } catch (final DatabaseUnitRuntimeException e)
             {
                 throw (DataSetException) e.getCause();
@@ -231,6 +236,60 @@ public class SortedTable extends AbstractTable
         }
 
         return _indexes[row].intValue();
+    }
+
+    /**
+     * Precomputes one sort key per (row, sort column) so the sort compares those keys directly
+     * instead of re-reading each cell -- and, in the default byString mode, re-running
+     * {@link DataType#asString(Object)} on it -- on every comparison. Memory cost is
+     * O(rows x sort columns) for the lifetime of this precompute call.
+     * <p>
+     * Only safe for the two built-in comparators ({@link RowComparator}, {@link
+     * RowComparatorByString}): their exact comparison mode (Comparable vs. string) is known, so
+     * an equivalent key can be precomputed for it. Gated by exact class, not <code>instanceof</code>,
+     * since both are non-final and reachable via the public {@link #setRowComparator(Comparator)}
+     * extension point -- a subclass overriding {@code compare(Column, Object, Object)} would have
+     * that override silently bypassed by the precomputed-key fast path. A {@link Comparator}
+     * supplied via {@link #setRowComparator(Comparator)} may implement arbitrary comparison logic,
+     * so its results cannot be safely precomputed; this method returns <code>null</code> in that
+     * case and the caller falls back to sorting with {@link #rowComparator} directly, reading
+     * cells as before.
+     *
+     * @param rowCount
+     *            The number of rows in the decorated table.
+     * @return A comparator over precomputed keys, or <code>null</code> if the current {@link
+     *         #rowComparator} is not exactly one of the two built-in ones.
+     * @throws DataSetException
+     */
+    private Comparator createPrecomputedKeyComparator(final int rowCount)
+            throws DataSetException
+    {
+        final boolean useComparable;
+        if (this.rowComparator.getClass() == RowComparator.class)
+        {
+            useComparable = true;
+        } else if (this.rowComparator.getClass() == RowComparatorByString.class)
+        {
+            useComparable = false;
+        } else
+        {
+            return null;
+        }
+
+        final Object[][] sortKeys = new Object[rowCount][_columns.length];
+        for (int row = 0; row < rowCount; row++)
+        {
+            for (int col = 0; col < _columns.length; col++)
+            {
+                final String columnName = _columns[col].getColumnName();
+                final Object value = _table.getValue(row, columnName);
+                sortKeys[row][col] =
+                        useComparable || value == null ? value
+                                : DataType.asString(value);
+            }
+        }
+
+        return new PrecomputedKeyComparator(sortKeys, _columns, useComparable);
     }
 
     /**
@@ -486,6 +545,70 @@ public class SortedTable extends AbstractTable
             final String stringValue2 = DataType.asString(value2);
             final int result = stringValue1.compareTo(stringValue2);
             return result;
+        }
+    }
+
+    /**
+     * Compares rows by their precomputed sort keys (see
+     * {@link SortedTable#createPrecomputedKeyComparator(int)}), reusing the exact null-ordering
+     * and per-column compare logic of {@link AbstractRowComparator#compare(Object, Object)}
+     * without re-reading or re-converting cell values.
+     */
+    private static final class PrecomputedKeyComparator implements Comparator
+    {
+        private final Object[][] sortKeys;
+        private final Column[] sortColumns;
+        private final boolean useComparable;
+
+        private PrecomputedKeyComparator(final Object[][] sortKeys,
+                final Column[] sortColumns, final boolean useComparable)
+        {
+            this.sortKeys = sortKeys;
+            this.sortColumns = sortColumns;
+            this.useComparable = useComparable;
+        }
+
+        @Override
+        public int compare(final Object o1, final Object o2)
+        {
+            final Object[] keys1 = sortKeys[((Integer) o1).intValue()];
+            final Object[] keys2 = sortKeys[((Integer) o2).intValue()];
+
+            for (int col = 0; col < sortColumns.length; col++)
+            {
+                final Object key1 = keys1[col];
+                final Object key2 = keys2[col];
+
+                if (key1 == null && key2 == null)
+                {
+                    continue;
+                }
+                if (key1 == null)
+                {
+                    return -1;
+                }
+                if (key2 == null)
+                {
+                    return 1;
+                }
+
+                final int result;
+                try
+                {
+                    result = useComparable
+                            ? sortColumns[col].getDataType().compare(key1,
+                                    key2)
+                            : ((String) key1).compareTo((String) key2);
+                } catch (final TypeCastException e)
+                {
+                    throw new DatabaseUnitRuntimeException(e);
+                }
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+            return 0;
         }
     }
 

--- a/src/main/java/org/dbunit/dataset/csv/CsvDataSetWriter.java
+++ b/src/main/java/org/dbunit/dataset/csv/CsvDataSetWriter.java
@@ -23,6 +23,7 @@ package org.dbunit.dataset.csv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -128,7 +129,7 @@ public class CsvDataSetWriter implements IDataSetConsumer {
         try {
             _activeMetaData = metaData;
             String tableName = _activeMetaData.getTableName();
-            setWriter(new FileWriter(getTheDirectory() + File.separator + tableName + ".csv"));
+            setWriter(new BufferedWriter(new FileWriter(getTheDirectory() + File.separator + tableName + ".csv")));
             writeColumnNames();
             getWriter().write(System.getProperty("line.separator"));
         } catch (IOException e) {
@@ -196,6 +197,24 @@ public class CsvDataSetWriter implements IDataSetConsumer {
             getWriter().write(System.getProperty("line.separator"));
         } catch (IOException e) {
             throw new DataSetException(e);
+        } catch (DataSetException e) {
+            // Rows already written for this table sit in the BufferedWriter until
+            // endTable() closes it; since a row failure here skips endTable()
+            // entirely, flush explicitly so they still reach disk.
+            flushWriterQuietly();
+            throw e;
+        }
+    }
+
+    private void flushWriterQuietly() {
+        logger.debug("flushWriterQuietly() - start");
+
+        try {
+            if (getWriter() != null) {
+                getWriter().flush();
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to flush writer after a row error", e);
         }
     }
 

--- a/src/main/java/org/dbunit/dataset/csv/CsvProducer.java
+++ b/src/main/java/org/dbunit/dataset/csv/CsvProducer.java
@@ -118,6 +118,10 @@ public class CsvProducer implements IDataSetProducer {
                 columnName = columnName.trim();
                 columns[i] = new Column(columnName, DataType.UNKNOWN);
             }
+            // Drop the reference once consumed: readData otherwise holds every row
+            // in memory for as long as the CachedDataSet being built from it, even
+            // though each row is redundant the moment _consumer.row() returns it.
+            readData.set(0, null);
 
             String tableName = theDataFile.getName().substring(0, theDataFile.getName().indexOf(".csv"));
             ITableMetaData metaData = new DefaultTableMetaData(tableName, columns);
@@ -129,6 +133,7 @@ public class CsvProducer implements IDataSetProducer {
                     row[col] = row[col].equals(CsvDataSetWriter.NULL) ? null : row[col];
                 }
                 _consumer.row(row);
+                readData.set(i, null);
             }
             _consumer.endTable();
         } catch (PipelineException e) {

--- a/src/main/java/org/dbunit/dataset/datatype/TimestampDataType.java
+++ b/src/main/java/org/dbunit/dataset/datatype/TimestampDataType.java
@@ -111,11 +111,14 @@ public class TimestampDataType extends AbstractDataType
 
             String zoneValue = null;
 
-            final Matcher tzMatcher = TIMEZONE_REGEX.matcher(stringValue);
-            if (tzMatcher.matches() && tzMatcher.group(2) != null)
+            if (couldHaveTimezoneSuffix(stringValue))
             {
-                stringValue = tzMatcher.group(1);
-                zoneValue = tzMatcher.group(2);
+                final Matcher tzMatcher = TIMEZONE_REGEX.matcher(stringValue);
+                if (tzMatcher.matches() && tzMatcher.group(2) != null)
+                {
+                    stringValue = tzMatcher.group(1);
+                    zoneValue = tzMatcher.group(2);
+                }
             }
 
             Timestamp ts = null;
@@ -177,6 +180,31 @@ public class TimestampDataType extends AbstractDataType
         }
 
         throw new TypeCastException(value, this);
+    }
+
+    /**
+     * Cheaply rules out strings that {@link #TIMEZONE_REGEX} can never match, so
+     * the majority of plain timestamp values never pay for constructing a
+     * {@link Matcher} and running the greedy {@code (.*)}-leading pattern.
+     * <p>
+     * The regex requires its final five characters to be a sign character
+     * ({@code +} or {@code -}) followed by four digits. A string that is too
+     * short, or whose character at that position is not a sign, provably cannot
+     * match, so the full match can be skipped.
+     * @param value The candidate string.
+     * @return {@code true} if {@code value} is long enough and has a sign
+     *         character at the position the regex requires, meaning a full match
+     *         attempt is worthwhile.
+     */
+    private static boolean couldHaveTimezoneSuffix(final String value)
+    {
+        final int length = value.length();
+        if (length < 6)
+        {
+            return false;
+        }
+        final char signChar = value.charAt(length - 5);
+        return signChar == '+' || signChar == '-';
     }
 
     @Override

--- a/src/main/java/org/dbunit/dataset/excel/XlsDataSet.java
+++ b/src/main/java/org/dbunit/dataset/excel/XlsDataSet.java
@@ -20,6 +20,7 @@
  */
 package org.dbunit.dataset.excel;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -64,7 +65,13 @@ public class XlsDataSet extends AbstractDataSet
      */
     public XlsDataSet(File file) throws IOException, DataSetException
     {
-        this(new FileInputStream(file));
+        _tables = super.createTableNameMap();
+
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file)))
+        {
+            Workbook workbook = createWorkbook(in);
+            loadSheets(workbook);
+        }
     }
 
     /**
@@ -74,19 +81,28 @@ public class XlsDataSet extends AbstractDataSet
     {
         _tables = super.createTableNameMap();
 
-        Workbook workbook;
-        try {
-            workbook = WorkbookFactory.create(in);
+        Workbook workbook = createWorkbook(in);
+        loadSheets(workbook);
+    }
+
+    private static Workbook createWorkbook(InputStream in) throws IOException
+    {
+        try
+        {
+            return WorkbookFactory.create(in);
         } catch (EncryptedDocumentException e) {
             throw new IOException(e);
         }
-		
+    }
+
+    private void loadSheets(Workbook workbook) throws DataSetException
+    {
         int sheetCount = workbook.getNumberOfSheets();
         for (int i = 0; i < sheetCount; i++)
         {
             ITable table = new XlsTable(workbook.getSheetName(i),
                     workbook.getSheetAt(i));
-            _tables.add(table.getTableMetaData().getTableName(), table);            
+            _tables.add(table.getTableMetaData().getTableName(), table);
         }
     }
 

--- a/src/main/java/org/dbunit/dataset/excel/XlsDataSetWriter.java
+++ b/src/main/java/org/dbunit/dataset/excel/XlsDataSetWriter.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
@@ -73,9 +74,17 @@ public class XlsDataSetWriter
      * only create one per format and reuse the same style for all cells with
      * the same format.
      */
-    private static final Map<Workbook, Map> cellStyleMap = new HashMap<Workbook, Map>();
+    private static final Map<Workbook, Map<Short, CellStyle>> cellStyleMap = new ConcurrentHashMap<Workbook, Map<Short, CellStyle>>();
 
     private CellStyle dateCellStyle;
+
+    /**
+     * Per-write() cache of the numeric cell format code for a given {@link BigDecimal}
+     * scale, so {@link #setNumericCell(Cell, BigDecimal, Workbook)} only needs to build the
+     * format string and resolve it via the workbook's {@link DataFormat} once per distinct
+     * scale, not once per cell.
+     */
+    private Map<Integer, Short> numericFormatCodeByScale;
 
     /**
      * Write the specified dataset to the specified Excel document.
@@ -86,63 +95,83 @@ public class XlsDataSetWriter
         logger.debug("write(dataSet={}, out={}) - start", dataSet, out);
 
         Workbook workbook = createWorkbook();
-
-        this.dateCellStyle = createDateCellStyle(workbook);
-        
-        int index = 0;
-        ITableIterator iterator = dataSet.iterator();
-        while(iterator.next())
+        try
         {
-            // create the table i.e. sheet
-            ITable table = iterator.getTable();
-            ITableMetaData metaData = table.getTableMetaData();
-            Sheet sheet = workbook.createSheet(metaData.getTableName());
+            this.dateCellStyle = createDateCellStyle(workbook);
+            this.numericFormatCodeByScale = new HashMap<Integer, Short>();
 
-            // write table metadata i.e. first row in sheet
-            workbook.setSheetName(index, metaData.getTableName());
+            int index = 0;
+            ITableIterator iterator = dataSet.iterator();
+            while(iterator.next())
+            {
+                // create the table i.e. sheet
+                ITable table = iterator.getTable();
+                ITableMetaData metaData = table.getTableMetaData();
+                Sheet sheet = workbook.createSheet(metaData.getTableName());
 
-            Row headerRow = sheet.createRow(0);
-            Column[] columns = metaData.getColumns();
-            for (int j = 0; j < columns.length; j++)
-            {
-                Column column = columns[j];
-                Cell cell = headerRow.createCell(j);
-                cell.setCellValue(column.getColumnName());
-            }
-            
-            // write table data
-            for (int j = 0; j < table.getRowCount(); j++)
-            {
-                Row row = sheet.createRow(j + 1);
-                for (int k = 0; k < columns.length; k++)
+                // write table metadata i.e. first row in sheet
+                workbook.setSheetName(index, metaData.getTableName());
+
+                Row headerRow = sheet.createRow(0);
+                Column[] columns = metaData.getColumns();
+                for (int j = 0; j < columns.length; j++)
                 {
-                    Column column = columns[k];
-                    Object value = table.getValue(j, column.getColumnName());
-                    if (value != null)
+                    Column column = columns[j];
+                    Cell cell = headerRow.createCell(j);
+                    cell.setCellValue(column.getColumnName());
+                }
+
+                // write table data
+                for (int j = 0; j < table.getRowCount(); j++)
+                {
+                    Row row = sheet.createRow(j + 1);
+                    for (int k = 0; k < columns.length; k++)
                     {
-                        Cell cell = row.createCell(k);
-                        if(value instanceof Date){
-                            setDateCell(cell, (Date)value, workbook);
-                        }
-                        else if(value instanceof BigDecimal){
-                            setNumericCell(cell, (BigDecimal)value, workbook);
-                        }
-                        else if(value instanceof Long){
-                            setDateCell(cell, new Date( ((Long)value).longValue()), workbook);
-                        }
-                        else {
-                            cell.setCellValue(DataType.asString(value));
+                        Column column = columns[k];
+                        Object value = table.getValue(j, column.getColumnName());
+                        if (value != null)
+                        {
+                            Cell cell = row.createCell(k);
+                            if(value instanceof Date){
+                                setDateCell(cell, (Date)value, workbook);
+                            }
+                            else if(value instanceof BigDecimal){
+                                setNumericCell(cell, (BigDecimal)value, workbook);
+                            }
+                            else if(value instanceof Long){
+                                setDateCell(cell, new Date( ((Long)value).longValue()), workbook);
+                            }
+                            else {
+                                cell.setCellValue(DataType.asString(value));
+                            }
                         }
                     }
                 }
+
+                index++;
             }
 
-            index++;
+            // write xls document
+            workbook.write(out);
+            out.flush();
         }
-
-        // write xls document
-        workbook.write(out);
-        out.flush();
+        finally
+        {
+            // cellStyleMap is static and otherwise retains every workbook ever written,
+            // for the JVM's lifetime, once this method returns.
+            cellStyleMap.remove(workbook);
+            // The default HSSFWorkbook holds no closeable resources, but createWorkbook() is
+            // protected specifically so subclasses can substitute a disk-backed Workbook (e.g.
+            // POI's SXSSFWorkbook), which would otherwise leak its temp file here.
+            try
+            {
+                workbook.close();
+            }
+            catch (IOException e)
+            {
+                logger.warn("Failed to close workbook", e);
+            }
+        }
     }
     
     protected static CellStyle createDateCellStyle(Workbook workbook) {
@@ -162,14 +191,7 @@ public class XlsDataSetWriter
     protected static Map<Short, CellStyle> findWorkbookCellStyleMap(
             Workbook workbook)
     {
-        Map<Short, CellStyle> map = cellStyleMap.get(workbook);
-        if (map == null)
-        {
-            map = new HashMap<Short, CellStyle>();
-            cellStyleMap.put(workbook, map);
-        }
-
-        return map;
+        return cellStyleMap.computeIfAbsent(workbook, k -> new HashMap<Short, CellStyle>());
     }
 
     protected static CellStyle findCellStyle(Workbook workbook,
@@ -256,15 +278,25 @@ public class XlsDataSetWriter
 
         cell.setCellValue( ((BigDecimal)value).doubleValue() );
 
-        DataFormat df = workbook.createDataFormat();
         int scale = ((BigDecimal)value).scale();
+        Integer scaleKey = Integer.valueOf(scale <= 0 ? 0 : scale);
+        Short cachedFormat = numericFormatCodeByScale.get(scaleKey);
         short format;
-        if(scale <= 0){
-            format = df.getFormat("####");
+        if (cachedFormat != null)
+        {
+            format = cachedFormat.shortValue();
         }
-        else {
-            String zeros = createZeros(((BigDecimal)value).scale());
-            format = df.getFormat("####." + zeros);
+        else
+        {
+            DataFormat df = workbook.createDataFormat();
+            if(scale <= 0){
+                format = df.getFormat("####");
+            }
+            else {
+                String zeros = createZeros(scale);
+                format = df.getFormat("####." + zeros);
+            }
+            numericFormatCodeByScale.put(scaleKey, Short.valueOf(format));
         }
         if(logger.isDebugEnabled())
             logger.debug("Using format '{}' for value '{}'.", String.valueOf(format), value);

--- a/src/main/java/org/dbunit/dataset/excel/XlsTable.java
+++ b/src/main/java/org/dbunit/dataset/excel/XlsTable.java
@@ -25,7 +25,9 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.poi.ss.usermodel.Cell;
@@ -62,7 +64,15 @@ class XlsTable extends AbstractTable
     private final Sheet _sheet;
     
     private final DecimalFormatSymbols symbols = new DecimalFormatSymbols();
-    
+
+    /**
+     * Cache of {@link DecimalFormat} instances keyed by format string, avoiding
+     * reconstructing one on every numeric cell read.
+     * {@code DecimalFormat} is not thread-safe; this cache is per-table-instance state,
+     * consistent with the rest of {@link XlsTable}.
+     */
+    private final Map<String, DecimalFormat> decimalFormatCache = new HashMap<String, DecimalFormat>();
+
 
     public XlsTable(String sheetName, Sheet sheet) throws DataSetException
     {
@@ -261,7 +271,11 @@ class XlsTable extends AbstractTable
         {
             if(!formatString.equals("General") && !formatString.equals("@")) {
                 logger.debug("formatString={}", formatString);
-                DecimalFormat nf = new DecimalFormat(formatString, symbols);
+                DecimalFormat nf = decimalFormatCache.get(formatString);
+                if(nf == null) {
+                    nf = new DecimalFormat(formatString, symbols);
+                    decimalFormatCache.put(formatString, nf);
+                }
                 resultString = nf.format(cellValue);
             }
         }

--- a/src/main/java/org/dbunit/dataset/xml/FlatDtdDataSet.java
+++ b/src/main/java/org/dbunit/dataset/xml/FlatDtdDataSet.java
@@ -21,6 +21,7 @@
 
 package org.dbunit.dataset.xml;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -92,7 +93,7 @@ public class FlatDtdDataSet extends AbstractDataSet implements IDataSetConsumer
             throws IOException, DataSetException
     {
         logger.debug("write(dataSet={}, out={}) - start", dataSet, out);
-        write(dataSet, new OutputStreamWriter(out));
+        write(dataSet, new BufferedWriter(new OutputStreamWriter(out)));
     }
 
     /**

--- a/src/main/java/org/dbunit/dataset/xml/FlatXmlProducer.java
+++ b/src/main/java/org/dbunit/dataset/xml/FlatXmlProducer.java
@@ -23,8 +23,11 @@ package org.dbunit.dataset.xml;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
@@ -106,6 +109,13 @@ public class FlatXmlProducer extends DefaultHandler implements IDataSetProducer,
      * The ordered table name map which also holds the currently active {@link ITableMetaData}
      */
     private OrderedTableNameMap _orderedTableNameMap;
+    /**
+     * Upper-cased column names of the currently active table's metadata, used as a fast
+     * existence check in {@link #handleMissingColumns(Attributes)} instead of catching
+     * {@link NoSuchColumnException}. Rebuilt whenever the active metadata changes: a new
+     * table starts, or column sensing merges a new column into it.
+     */
+    private Set _activeColumnNamesUpperCase;
 
     
     public FlatXmlProducer(InputSource xmlSource)
@@ -250,9 +260,25 @@ public class FlatXmlProducer extends DefaultHandler implements IDataSetProducer,
      * @return <code>true</code> if the given tableName is a new one
      * which means that it differs from the last active table name.
      */
-    private boolean isNewTable(String tableName) 
+    private boolean isNewTable(String tableName)
     {
         return !_orderedTableNameMap.isLastTable(tableName);
+    }
+
+    /**
+     * Rebuilds {@link #_activeColumnNamesUpperCase} from the given metadata's columns.
+     * Must be called whenever the active table's metadata changes.
+     * @param metaData The new active metadata to index.
+     */
+    private void rebuildActiveColumnNames(ITableMetaData metaData) throws DataSetException
+    {
+        Column[] columns = metaData.getColumns();
+        Set columnNames = new HashSet(columns.length);
+        for (int i = 0; i < columns.length; i++)
+        {
+            columnNames.add(columns[i].getColumnName().toUpperCase(Locale.ENGLISH));
+        }
+        _activeColumnNamesUpperCase = columnNames;
     }
 
 
@@ -275,20 +301,20 @@ public class FlatXmlProducer extends DefaultHandler implements IDataSetProducer,
 			throws DataSetException
 	{
 		List columnsToMerge = new ArrayList();
-		
+
 		ITableMetaData activeMetaData = getActiveMetaData();
-		// Search all columns that do not yet exist and collect them
+		// Search all columns that do not yet exist and collect them. Checked against
+		// _activeColumnNamesUpperCase (a plain Set membership test) rather than by calling
+		// getColumnIndex() and catching NoSuchColumnException as an existence test.
 		int attributeLength = attributes.getLength();
 		for (int i = 0 ; i < attributeLength; i++)
 		{
-			try {
-			    activeMetaData.getColumnIndex(attributes.getQName(i));
-			} 
-			catch (NoSuchColumnException e) {
+			if (!_activeColumnNamesUpperCase.contains(attributes.getQName(i).toUpperCase(Locale.ENGLISH)))
+			{
 				columnsToMerge.add(new Column(attributes.getQName(i), DataType.UNKNOWN));
 			}
 		}
-		
+
 		if (!columnsToMerge.isEmpty())
 		{
 			if (_columnSensing)
@@ -296,9 +322,10 @@ public class FlatXmlProducer extends DefaultHandler implements IDataSetProducer,
 	    		logger.debug("Column sensing enabled. Will create a new metaData with potentially new columns if needed");
 	    		activeMetaData = mergeTableMetaData(columnsToMerge, activeMetaData);
 	    		_orderedTableNameMap.update(activeMetaData.getTableName(), activeMetaData);
+	    		rebuildActiveColumnNames(activeMetaData);
 	    		// We also need to recreate the table, copying the data already collected from the old one to the new one
 	    		_consumer.startTable(activeMetaData);
-	    	} 
+	    	}
 	    	else
 	    	{
 	    		final StringBuilder extraColumnNames = new StringBuilder();
@@ -445,7 +472,8 @@ public class FlatXmlProducer extends DefaultHandler implements IDataSetProducer,
                     activeMetaData = createTableMetaData(qName, attributes);
                     _orderedTableNameMap.add(activeMetaData.getTableName(), activeMetaData);
                 }
-                
+                rebuildActiveColumnNames(activeMetaData);
+
                 // Notify start of new table to consumer
                 _consumer.startTable(activeMetaData);
                 _lineNumber = 0;

--- a/src/main/java/org/dbunit/dataset/xml/FlatXmlWriter.java
+++ b/src/main/java/org/dbunit/dataset/xml/FlatXmlWriter.java
@@ -228,5 +228,28 @@ public class FlatXmlWriter implements IDataSetConsumer
         {
             throw new DataSetException(e);
         }
+        catch (DataSetException e)
+        {
+            // Content already written for this document sits in the buffered
+            // underlying writer until close(); since a row failure here skips
+            // close() entirely (and close() itself would reject the now-unclosed
+            // tag stack), flush explicitly so already-written content isn't lost.
+            flushWriterQuietly();
+            throw e;
+        }
+    }
+
+    private void flushWriterQuietly()
+    {
+        logger.debug("flushWriterQuietly() - start");
+
+        try
+        {
+            _xmlWriter.flush();
+        }
+        catch (IOException e)
+        {
+            logger.warn("Failed to flush writer after a row error", e);
+        }
     }
 }

--- a/src/main/java/org/dbunit/dataset/xml/XmlDataSetWriter.java
+++ b/src/main/java/org/dbunit/dataset/xml/XmlDataSetWriter.java
@@ -287,6 +287,29 @@ public class XmlDataSetWriter implements IDataSetConsumer
         {
             throw new DataSetException(e);
         }
+        catch (DataSetException e)
+        {
+            // Content already written for this document sits in the buffered
+            // underlying writer until close(); since a row failure here skips
+            // close() entirely (and close() itself would reject the now-unclosed
+            // tag stack), flush explicitly so already-written content isn't lost.
+            flushWriterQuietly();
+            throw e;
+        }
+    }
+
+    private void flushWriterQuietly()
+    {
+        logger.debug("flushWriterQuietly() - start");
+
+        try
+        {
+            _xmlWriter.flush();
+        }
+        catch (IOException e)
+        {
+            logger.warn("Failed to flush writer after a row error", e);
+        }
     }
 
     /**

--- a/src/main/java/org/dbunit/dataset/yaml/YamlDataSet.java
+++ b/src/main/java/org/dbunit/dataset/yaml/YamlDataSet.java
@@ -25,6 +25,7 @@ import org.dbunit.dataset.CachedDataSet;
 import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.IDataSet;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -94,7 +95,7 @@ public class YamlDataSet extends CachedDataSet
     public static void write(IDataSet dataSet, OutputStream out)
     throws DataSetException
     {
-        write(dataSet, new OutputStreamWriter(out));
+        write(dataSet, new BufferedWriter(new OutputStreamWriter(out)));
     }
 
     /**

--- a/src/main/java/org/dbunit/operation/InsertOperation.java
+++ b/src/main/java/org/dbunit/operation/InsertOperation.java
@@ -109,7 +109,10 @@ public class InsertOperation extends AbstractBatchOperation
 
     protected BitSet getIgnoreMapping(ITable table, int row) throws DataSetException
     {
-    	logger.debug("getIgnoreMapping(table={}, row={}) - start", table, row);
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("getIgnoreMapping(table={}, row={}) - start", table, row);
+        }
 
         Column[] columns = table.getTableMetaData().getColumns();
 
@@ -130,8 +133,11 @@ public class InsertOperation extends AbstractBatchOperation
     protected boolean equalsIgnoreMapping(BitSet ignoreMapping, ITable table,
             int row) throws DataSetException
     {
-    	logger.debug("equalsIgnoreMapping(ignoreMapping={}, table={}, row={}) - start",
-    			 ignoreMapping, table, row);
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("equalsIgnoreMapping(ignoreMapping={}, table={}, row={}) - start",
+                    ignoreMapping, table, row);
+        }
 
         Column[] columns = table.getTableMetaData().getColumns();
 

--- a/src/main/java/org/dbunit/util/SQLHelper.java
+++ b/src/main/java/org/dbunit/util/SQLHelper.java
@@ -67,16 +67,20 @@ public class SQLHelper {
      * @param conn connection with the database
      * @param table table name
      * @return name of primary column for a table (assuming it's just 1 column).
-     * @throws SQLException raised while getting the meta data
+     * @throws SQLException Raised while getting the meta data, or if the table has no primary key.
      */
     public static String getPrimaryKeyColumn( Connection conn, String table ) throws SQLException {
         logger.debug("getPrimaryKeyColumn(conn={}, table={}) - start", conn, table);
 
         DatabaseMetaData metadata = conn.getMetaData();
-        ResultSet rs = metadata.getPrimaryKeys( null, null, table );
-        rs.next();
-        String pkColumn = rs.getString(4);
-        return pkColumn;
+        try (ResultSet rs = metadata.getPrimaryKeys( null, null, table ))
+        {
+            if (!rs.next())
+            {
+                throw new SQLException("No primary key found for table '" + table + "'.");
+            }
+            return rs.getString(4);
+        }
     }
 
     /**

--- a/src/main/java/org/dbunit/util/search/DepthFirstSearch.java
+++ b/src/main/java/org/dbunit/util/search/DepthFirstSearch.java
@@ -212,7 +212,7 @@ public class DepthFirstSearch implements ISearchAlgorithm {
               // and recursively search these nodes
               IEdge edge = (IEdge) iterator.next();
               Object toNode = edge.getTo();
-              search(toNode, currentSearchDepth++);
+              search(toNode, currentSearchDepth + 1);
             }
           }
     }
@@ -270,7 +270,7 @@ public class DepthFirstSearch implements ISearchAlgorithm {
             Object toNode = edge.getTo();
             if ( toNode.equals(node) ) {
               Object fromNode = edge.getFrom();
-              reverseSearch(fromNode, currentSearchDepth++);
+              reverseSearch(fromNode, currentSearchDepth + 1);
             }
           }
         }

--- a/src/main/java/org/dbunit/util/xml/XmlWriter.java
+++ b/src/main/java/org/dbunit/util/xml/XmlWriter.java
@@ -56,6 +56,7 @@ package org.dbunit.util.xml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -456,6 +457,19 @@ public class XmlWriter
             throw new IOException("Tags are not all closed. " + "Possibly, "
                     + this.stack.pop() + " is unclosed. ");
         }
+    }
+
+    /**
+     * Flushes the underlying writer, without {@link #close()}'s unclosed-tags check.
+     * Intended for callers recovering from a write error mid-document, so already-written
+     * content reaches the underlying stream even though the document itself is incomplete.
+     * @throws IOException on a failure to flush the underlying writer.
+     */
+    public void flush() throws IOException
+    {
+        logger.debug("flush() - start");
+
+        this.out.flush();
     }
 
     /**
@@ -914,8 +928,10 @@ public class XmlWriter
         if (this.out != null)
         {
             setEncoding(charset);
-            // if (!(this.out instanceof BufferedWriter))
-            // this.out = new BufferedWriter(this.out);
+            if (!(this.out instanceof BufferedWriter))
+            {
+                this.out = new BufferedWriter(this.out);
+            }
         }
     }
 

--- a/src/test/java/org/dbunit/assertion/DbUnitAssertTest.java
+++ b/src/test/java/org/dbunit/assertion/DbUnitAssertTest.java
@@ -354,6 +354,35 @@ class DbUnitAssertTest
         assertThat(diff.getActualValue()).as("actual value.").isEqualTo("Wrong");
     }
 
+    @Test
+    void testAssertEquals_multiRowMismatchTable_reportsDifferencePerCell()
+            throws DatabaseUnitException
+    {
+        final IDataSet expected = new DataSetBuilder()
+                .table("T").columns("ID", "NAME")
+                .row(1, "Alice")
+                .row(2, "Carol")
+                .row(3, "Erin")
+                .build();
+
+        final IDataSet actual = new DataSetBuilder()
+                .table("T").columns("ID", "NAME")
+                .row(9, "Bob")
+                .row(8, "Dave")
+                .row(7, "Frank")
+                .build();
+
+        final DiffCollectingFailureHandler handler = new DiffCollectingFailureHandler();
+        assertion.assertEquals(expected.getTable("T"), actual.getTable("T"), handler);
+
+        final int rowCount = 3;
+        final int columnCount = 2;
+        assertThat(handler.getDiffList())
+                .as("Every (row, column) cell should still be compared and reported once, "
+                        + "proving the hoisted row count does not skip or duplicate cells.")
+                .hasSize(rowCount * columnCount);
+    }
+
     // -------------------------------------------------------------------------
     // assertEquals with additionalColumnInfo
     // -------------------------------------------------------------------------

--- a/src/test/java/org/dbunit/database/DatabaseSequenceFilterTest.java
+++ b/src/test/java/org/dbunit/database/DatabaseSequenceFilterTest.java
@@ -1,0 +1,103 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Statement;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DatabaseSequenceFilter}, run against a real H2 in-memory database
+ * (rather than mocked {@link java.sql.ResultSet} rows) so that the foreign key metadata
+ * driving the sort is genuine. A {@link org.mockito.Mockito#spy(Object)} wraps the real
+ * {@link DatabaseMetaData} to count JDBC calls for the caching perf-guard.
+ *
+ * @since 3.2.1
+ */
+class DatabaseSequenceFilterTest
+{
+    private IDatabaseConnection connection;
+
+    @AfterEach
+    void tearDown() throws Exception
+    {
+        if (connection != null)
+        {
+            connection.close();
+        }
+    }
+
+    @Test
+    void testSort_multipleDependentTables_ordersChildrenAfterParents() throws Exception
+    {
+        connection = InMemoryDatabaseConnection.create();
+        final Statement stmt = connection.getConnection().createStatement();
+        stmt.execute("CREATE TABLE PARENT (ID INT PRIMARY KEY)");
+        stmt.execute(
+                "CREATE TABLE CHILD (ID INT PRIMARY KEY, PARENT_ID INT REFERENCES PARENT(ID))");
+        stmt.close();
+
+        final String[] sorted = DatabaseSequenceFilter.sortTableNames(connection,
+                new String[] {"CHILD", "PARENT"});
+
+        assertThat(Arrays.asList(sorted))
+                .as("PARENT must come before CHILD, since CHILD has a FK referencing PARENT.")
+                .containsExactly("PARENT", "CHILD");
+    }
+
+    @Test
+    void testSort_multipleTables_fetchesImportedKeysOncePerTable() throws Exception
+    {
+        final Connection realConnection = InMemoryDatabaseConnection.create().getConnection();
+        final Statement stmt = realConnection.createStatement();
+        stmt.execute("CREATE TABLE A (ID INT PRIMARY KEY)");
+        stmt.execute("CREATE TABLE B (ID INT PRIMARY KEY, A_ID INT REFERENCES A(ID))");
+        stmt.execute("CREATE TABLE C (ID INT PRIMARY KEY, B_ID INT REFERENCES B(ID))");
+        stmt.close();
+
+        final DatabaseMetaData spyMetaData = spy(realConnection.getMetaData());
+        final Connection spyConnection = spy(realConnection);
+        when(spyConnection.getMetaData()).thenReturn(spyMetaData);
+        connection = new DatabaseConnection(spyConnection);
+
+        DatabaseSequenceFilter.sortTableNames(connection, new String[] {"C", "B", "A"});
+
+        verify(spyMetaData, times(1)).getImportedKeys(any(), any(), eq("A"));
+        verify(spyMetaData, times(1)).getImportedKeys(any(), any(), eq("B"));
+        verify(spyMetaData, times(1)).getImportedKeys(any(), any(), eq("C"));
+        verify(spyMetaData, times(1)).getExportedKeys(any(), any(), eq("A"));
+        verify(spyMetaData, times(1)).getExportedKeys(any(), any(), eq("B"));
+        verify(spyMetaData, times(1)).getExportedKeys(any(), any(), eq("C"));
+    }
+
+}

--- a/src/test/java/org/dbunit/database/DatabaseSequenceFilterTest.java
+++ b/src/test/java/org/dbunit/database/DatabaseSequenceFilterTest.java
@@ -30,8 +30,10 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -98,6 +100,91 @@ class DatabaseSequenceFilterTest
         verify(spyMetaData, times(1)).getExportedKeys(any(), any(), eq("A"));
         verify(spyMetaData, times(1)).getExportedKeys(any(), any(), eq("B"));
         verify(spyMetaData, times(1)).getExportedKeys(any(), any(), eq("C"));
+    }
+
+    @Test
+    void testSort_diamondDependencies_returnsValidTopologicalOrder() throws Exception
+    {
+        connection = InMemoryDatabaseConnection.create();
+        final Statement stmt = connection.getConnection().createStatement();
+        stmt.execute("CREATE TABLE A (ID INT PRIMARY KEY)");
+        stmt.execute("CREATE TABLE B (ID INT PRIMARY KEY, A_ID INT REFERENCES A(ID))");
+        stmt.execute("CREATE TABLE C (ID INT PRIMARY KEY, A_ID INT REFERENCES A(ID))");
+        stmt.execute("CREATE TABLE D (ID INT PRIMARY KEY, B_ID INT REFERENCES B(ID), "
+                + "C_ID INT REFERENCES C(ID))");
+        stmt.close();
+
+        final String[] sorted = DatabaseSequenceFilter.sortTableNames(connection,
+                new String[] {"D", "C", "B", "A"});
+        final List<String> order = Arrays.asList(sorted);
+
+        assertThat(order.indexOf("A")).as("A must precede B, its dependent.")
+                .isLessThan(order.indexOf("B"));
+        assertThat(order.indexOf("A")).as("A must precede C, its dependent.")
+                .isLessThan(order.indexOf("C"));
+        assertThat(order.indexOf("B")).as("B must precede D, its dependent.")
+                .isLessThan(order.indexOf("D"));
+        assertThat(order.indexOf("C")).as("C must precede D, its dependent.")
+                .isLessThan(order.indexOf("D"));
+    }
+
+    @Test
+    void testSort_independentTables_preservesOriginalOrder() throws Exception
+    {
+        connection = InMemoryDatabaseConnection.create();
+        final Statement stmt = connection.getConnection().createStatement();
+        stmt.execute("CREATE TABLE X (ID INT PRIMARY KEY)");
+        stmt.execute("CREATE TABLE Y (ID INT PRIMARY KEY)");
+        stmt.execute("CREATE TABLE Z (ID INT PRIMARY KEY)");
+        stmt.close();
+
+        final String[] sorted = DatabaseSequenceFilter.sortTableNames(connection,
+                new String[] {"Z", "X", "Y"});
+
+        assertThat(Arrays.asList(sorted))
+                .as("Tables with no FK relationship between them should keep their input order.")
+                .containsExactly("Z", "X", "Y");
+    }
+
+    @Test
+    void testSort_chainReversedInput_reordersChain() throws Exception
+    {
+        connection = InMemoryDatabaseConnection.create();
+        final Statement stmt = connection.getConnection().createStatement();
+        stmt.execute("CREATE TABLE A (ID INT PRIMARY KEY)");
+        stmt.execute("CREATE TABLE B (ID INT PRIMARY KEY, A_ID INT REFERENCES A(ID))");
+        stmt.execute("CREATE TABLE C (ID INT PRIMARY KEY, B_ID INT REFERENCES B(ID))");
+        stmt.close();
+
+        final String[] sorted = DatabaseSequenceFilter.sortTableNames(connection,
+                new String[] {"C", "B", "A"});
+
+        assertThat(Arrays.asList(sorted))
+                .as("A reverse-order chain A<-B<-C must be fully reordered to A, B, C.")
+                .containsExactly("A", "B", "C");
+    }
+
+    @Test
+    void testSort_lowerCaseFoldingDatabaseAndMismatchedInputCase_doesNotThrowSpuriousCycleException()
+            throws Exception
+    {
+        final Connection realConnection = DriverManager.getConnection(
+                "jdbc:h2:mem:dbunit_seqfilter_lowercase;DATABASE_TO_LOWER=TRUE");
+        final Statement stmt = realConnection.createStatement();
+        stmt.execute("CREATE TABLE PARENT (ID INT PRIMARY KEY)");
+        stmt.execute(
+                "CREATE TABLE CHILD (ID INT PRIMARY KEY, PARENT_ID INT REFERENCES PARENT(ID))");
+        stmt.close();
+        connection = new DatabaseConnection(realConnection);
+
+        final String[] sorted = DatabaseSequenceFilter.sortTableNames(connection,
+                new String[] {"CHILD", "PARENT"});
+
+        assertThat(Arrays.asList(sorted))
+                .as("PARENT must precede CHILD without a spurious CyclicTablesDependencyException, "
+                        + "even though the database folds unquoted identifiers to lowercase and the "
+                        + "caller-supplied names ('CHILD', 'PARENT') do not match that stored case.")
+                .containsExactly("PARENT", "CHILD");
     }
 
 }

--- a/src/test/java/org/dbunit/database/PrimaryKeyFilterTest.java
+++ b/src/test/java/org/dbunit/database/PrimaryKeyFilterTest.java
@@ -21,11 +21,26 @@
 package org.dbunit.database;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.dbunit.database.PrimaryKeyFilter.PkTableMap;
+import org.dbunit.database.search.ForeignKeyRelationshipEdge;
+import org.dbunit.dataset.Column;
+import org.dbunit.dataset.DefaultDataSet;
+import org.dbunit.dataset.DefaultTable;
+import org.dbunit.dataset.DefaultTableMetaData;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.datatype.DataType;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -254,5 +269,53 @@ class PrimaryKeyFilterTest
         final String result = filter.toString();
         assertThat(result).as("toString is not empty.").isNotBlank();
         assertThat(result).as("toString includes reverseScan flag.").contains("reverseScan=true");
+    }
+
+    // -------------------------------------------------------------------------
+    // PrimaryKeyFilter scanPKs result set closing tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testIterator_multiplePksToScan_closesResultSetPerIteration() throws Exception
+    {
+        // CHILD has an FK column (PARENT_ID) referencing PARENT.ID.
+        final Column[] childColumns = new Column[] {
+                new Column("ID", DataType.NUMERIC),
+                new Column("PARENT_ID", DataType.NUMERIC)};
+        final DefaultTable childTable = new DefaultTable(
+                new DefaultTableMetaData("CHILD", childColumns, new String[] {"ID"}));
+        final Column[] parentColumns =
+                new Column[] {new Column("ID", DataType.NUMERIC)};
+        final DefaultTable parentTable = new DefaultTable(
+                new DefaultTableMetaData("PARENT", parentColumns, new String[] {"ID"}));
+        final IDataSet dataSet = new DefaultDataSet(childTable, parentTable);
+
+        final PreparedStatement pstmt = mock(PreparedStatement.class);
+        final ResultSet rs1 = mock(ResultSet.class);
+        final ResultSet rs2 = mock(ResultSet.class);
+        when(pstmt.executeQuery()).thenReturn(rs1, rs2);
+        final Connection connection = mock(Connection.class);
+        when(connection.prepareStatement(anyString())).thenReturn(pstmt);
+        final IDatabaseConnection databaseConnection = mock(IDatabaseConnection.class);
+        when(databaseConnection.getConnection()).thenReturn(connection);
+
+        final PkTableMap allowedPKs = new PkTableMap();
+        allowedPKs.add("CHILD", Integer.valueOf(1));
+        allowedPKs.add("CHILD", Integer.valueOf(2));
+
+        final PrimaryKeyFilter filter =
+                new PrimaryKeyFilter(databaseConnection, allowedPKs, false);
+        filter.nodeAdded("CHILD");
+        filter.nodeAdded("PARENT");
+        filter.edgeAdded(new ForeignKeyRelationshipEdge("CHILD", "PARENT",
+                "PARENT_ID", "ID"));
+
+        // searchPKs() -- and therefore scanPKs() -- runs synchronously inside iterator().
+        filter.iterator(dataSet, false);
+
+        verify(pstmt, times(2)).executeQuery();
+        // Each iteration's own ResultSet must be closed, not just the last one.
+        verify(rs1, times(1)).close();
+        verify(rs2, times(1)).close();
     }
 }

--- a/src/test/java/org/dbunit/database/QueryDataSetIT.java
+++ b/src/test/java/org/dbunit/database/QueryDataSetIT.java
@@ -28,6 +28,8 @@ import org.dbunit.DatabaseEnvironment;
 import org.dbunit.dataset.AbstractDataSetTest;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
+import org.dbunit.dataset.ITableIterator;
+import org.dbunit.dataset.ITableMetaData;
 import org.dbunit.dataset.NoSuchColumnException;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
@@ -252,5 +254,26 @@ class QueryDataSetIT extends AbstractDataSetTest
         ptds.addTable("SECOND_TABLE",
                 "SELECT * from SECOND_TABLE where COLUMN0='row 0 col 0' and COLUMN2='row 0 col 2'");
         ptds.addTable("PK_TABLE", null);
+    }
+
+    @Test
+    void testIteratorGetTableMetaData_calledBeforeGetTable_returnsConsistentDataAndMetaData()
+            throws Exception
+    {
+        final QueryDataSet ptds = new QueryDataSet(_connection);
+        ptds.addTable("PK_TABLE", "SELECT * FROM PK_TABLE where PK0 = 0");
+
+        final ITableIterator iterator = ptds.iterator();
+        assertThat(iterator.next()).as("PK_TABLE entry should be present.").isTrue();
+
+        // QueryTableIterator.getTableMetaData() delegates to getTable() and caches the
+        // result, rather than issuing its own separate query, so calling it first must
+        // not disturb the real JDBC cursor a subsequent getTable() call reads from.
+        final ITableMetaData metaData = iterator.getTableMetaData();
+        assertThat(metaData.getColumnIndex("PK0")).as("PK0 column index.").isZero();
+
+        final ITable table = iterator.getTable();
+        assertThat(table.getValue(0, "PK0")).as("PK0 value.").hasToString("0");
+        assertThat(table.getRowCount()).as("row count.").isEqualTo(1);
     }
 }

--- a/src/test/java/org/dbunit/database/QueryTableIteratorTest.java
+++ b/src/test/java/org/dbunit/database/QueryTableIteratorTest.java
@@ -1,0 +1,156 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2004, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dbunit.database.QueryDataSet.TableEntry;
+import org.dbunit.dataset.DefaultTableMetaData;
+import org.dbunit.dataset.ITableMetaData;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link QueryTableIterator}.
+ *
+ * @since 3.2.1
+ */
+class QueryTableIteratorTest
+{
+    private static List<TableEntry> singleEntry(final TableEntry entry)
+    {
+        final List<TableEntry> entries = new ArrayList<>();
+        entries.add(entry);
+        return entries;
+    }
+
+    @Test
+    void testGetTableMetaDataThenGetTable_withNoQueryEntry_createsTableOnlyOnce()
+            throws Exception
+    {
+        final ITableMetaData metaData =
+                new DefaultTableMetaData("MYTABLE", new org.dbunit.dataset.Column[0]);
+        final IResultSetTable table = mock(IResultSetTable.class);
+        when(table.getTableMetaData()).thenReturn(metaData);
+
+        final IDatabaseConnection connection = mock(IDatabaseConnection.class);
+        when(connection.createTable("MYTABLE")).thenReturn(table);
+
+        final QueryTableIterator iterator = new QueryTableIterator(
+                singleEntry(new TableEntry("MYTABLE", null)), connection);
+        iterator.next();
+
+        final ITableMetaData actualMetaData = iterator.getTableMetaData();
+        final Object actualTable = iterator.getTable();
+
+        assertThat(actualMetaData).as("metadata from getTableMetaData().")
+                .isSameAs(metaData);
+        assertThat(actualTable).as("table from getTable().").isSameAs(table);
+        verify(connection, times(1)).createTable("MYTABLE");
+    }
+
+    @Test
+    void testGetTableThenGetTableMetaData_withNoQueryEntry_createsTableOnlyOnce()
+            throws Exception
+    {
+        final ITableMetaData metaData =
+                new DefaultTableMetaData("MYTABLE", new org.dbunit.dataset.Column[0]);
+        final IResultSetTable table = mock(IResultSetTable.class);
+        when(table.getTableMetaData()).thenReturn(metaData);
+
+        final IDatabaseConnection connection = mock(IDatabaseConnection.class);
+        when(connection.createTable("MYTABLE")).thenReturn(table);
+
+        final QueryTableIterator iterator = new QueryTableIterator(
+                singleEntry(new TableEntry("MYTABLE", null)), connection);
+        iterator.next();
+
+        final Object actualTable = iterator.getTable();
+        final ITableMetaData actualMetaData = iterator.getTableMetaData();
+
+        assertThat(actualTable).as("table from getTable().").isSameAs(table);
+        assertThat(actualMetaData).as("metadata from getTableMetaData().")
+                .isSameAs(metaData);
+        verify(connection, times(1)).createTable("MYTABLE");
+    }
+
+    @Test
+    void testGetTableMetaDataThenGetTable_withQueryEntry_createsTableOnlyOnce()
+            throws Exception
+    {
+        final String query = "select * from MYTABLE where ID > 1";
+        final ITableMetaData metaData =
+                new DefaultTableMetaData("MYTABLE", new org.dbunit.dataset.Column[0]);
+        final IResultSetTable table = mock(IResultSetTable.class);
+        when(table.getTableMetaData()).thenReturn(metaData);
+
+        final IResultSetTableFactory factory = mock(IResultSetTableFactory.class);
+        when(factory.createTable(any(String.class), any(String.class), any(IDatabaseConnection.class)))
+                .thenReturn(table);
+
+        final DatabaseConfig config = new DatabaseConfig();
+        config.setProperty(DatabaseConfig.PROPERTY_RESULTSET_TABLE_FACTORY, factory);
+
+        final IDatabaseConnection connection = mock(IDatabaseConnection.class);
+        when(connection.getConfig()).thenReturn(config);
+
+        final QueryTableIterator iterator = new QueryTableIterator(
+                singleEntry(new TableEntry("MYTABLE", query)), connection);
+        iterator.next();
+
+        final ITableMetaData actualMetaData = iterator.getTableMetaData();
+        final Object actualTable = iterator.getTable();
+
+        assertThat(actualMetaData).as("metadata from getTableMetaData().")
+                .isSameAs(metaData);
+        assertThat(actualTable).as("table from getTable().").isSameAs(table);
+        verify(factory, times(1)).createTable("MYTABLE", query, connection);
+    }
+
+    @Test
+    void testNext_afterGetTable_closesPreviousTableBeforeAdvancing() throws Exception
+    {
+        final IResultSetTable table1 = mock(IResultSetTable.class);
+        final IResultSetTable table2 = mock(IResultSetTable.class);
+
+        final IDatabaseConnection connection = mock(IDatabaseConnection.class);
+        when(connection.createTable("T1")).thenReturn(table1);
+        when(connection.createTable("T2")).thenReturn(table2);
+
+        final List<TableEntry> entries = new ArrayList<>();
+        entries.add(new TableEntry("T1", null));
+        entries.add(new TableEntry("T2", null));
+
+        final QueryTableIterator iterator = new QueryTableIterator(entries, connection);
+        iterator.next();
+        iterator.getTable();
+        iterator.next();
+
+        verify(table1, times(1)).close();
+    }
+}

--- a/src/test/java/org/dbunit/database/ResultSetTableMetaDataTest.java
+++ b/src/test/java/org/dbunit/database/ResultSetTableMetaDataTest.java
@@ -1,0 +1,205 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.dbunit.dataset.Column;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ResultSetTableMetaData}, run against a real H2 in-memory database so
+ * that the {@link java.sql.ResultSetMetaData} and {@link DatabaseMetaData} behavior driving
+ * column resolution is genuine. Call counts are verified via {@link org.mockito.Mockito#spy}
+ * wrappers rather than fully mocked JDBC objects.
+ *
+ * @since 3.2.1
+ */
+class ResultSetTableMetaDataTest
+{
+    private static final String CREATE_TABLE_SQL = "CREATE TABLE MULTI_COL_TABLE "
+            + "(ID INT PRIMARY KEY, NAME VARCHAR(50), AMOUNT DECIMAL(10,2))";
+
+    private IDatabaseConnection connection;
+
+    @AfterEach
+    void tearDown() throws Exception
+    {
+        if (connection != null)
+        {
+            connection.close();
+        }
+    }
+
+    @Test
+    void testCreateMetaData_multiColumnSingleTable_singleGetColumnsQuery() throws Exception
+    {
+        final Connection realConnection = InMemoryDatabaseConnection.create().getConnection();
+        final Statement ddlStmt = realConnection.createStatement();
+        ddlStmt.execute(CREATE_TABLE_SQL);
+        ddlStmt.close();
+
+        final DatabaseMetaData spyMetaData = spy(realConnection.getMetaData());
+        final Connection spyConnection = spy(realConnection);
+        when(spyConnection.getMetaData()).thenReturn(spyMetaData);
+        connection = new DatabaseConnection(spyConnection);
+
+        final Statement queryStmt = spyConnection.createStatement();
+        final ResultSet resultSet =
+                queryStmt.executeQuery("SELECT * FROM MULTI_COL_TABLE");
+
+        final ResultSetTableMetaData metaData =
+                new ResultSetTableMetaData("MULTI_COL_TABLE", resultSet, connection, false);
+        final Column[] columns = metaData.getColumns();
+
+        assertThat(columns).as("column count.").hasSize(3);
+        assertThat(columns[0].getColumnName()).as("column 0 name.")
+                .isEqualToIgnoringCase("ID");
+        assertThat(columns[1].getColumnName()).as("column 1 name.")
+                .isEqualToIgnoringCase("NAME");
+        assertThat(columns[2].getColumnName()).as("column 2 name.")
+                .isEqualToIgnoringCase("AMOUNT");
+
+        verify(spyMetaData, times(1)).getColumns(any(), any(), eq("MULTI_COL_TABLE"), eq("%"));
+    }
+
+    @Test
+    void testCreateMetaData_customMetadataHandler_fetchesColumnsPerColumn() throws Exception
+    {
+        final Connection realConnection = InMemoryDatabaseConnection.create().getConnection();
+        final Statement ddlStmt = realConnection.createStatement();
+        ddlStmt.execute(CREATE_TABLE_SQL);
+        ddlStmt.close();
+
+        connection = new DatabaseConnection(realConnection);
+        final IMetadataHandler customHandler =
+                spy(new DelegatingMetadataHandler(new DefaultMetadataHandler()));
+        connection.getConfig().setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER,
+                customHandler);
+
+        final Statement queryStmt = realConnection.createStatement();
+        final ResultSet resultSet =
+                queryStmt.executeQuery("SELECT * FROM MULTI_COL_TABLE");
+
+        final ResultSetTableMetaData metaData =
+                new ResultSetTableMetaData("MULTI_COL_TABLE", resultSet, connection, false);
+        final Column[] columns = metaData.getColumns();
+
+        assertThat(columns).as("column count.").hasSize(3);
+
+        verify(customHandler, times(3)).getColumns(any(), any(), eq("MULTI_COL_TABLE"));
+    }
+
+    @Test
+    void testCreateMetaData_caseSensitiveMetadataEnabled_resolvesExactCaseColumnsViaCache()
+            throws Exception
+    {
+        final Connection realConnection = InMemoryDatabaseConnection.create().getConnection();
+        final Statement ddlStmt = realConnection.createStatement();
+        ddlStmt.execute(CREATE_TABLE_SQL);
+        ddlStmt.close();
+
+        connection = new DatabaseConnection(realConnection);
+
+        final Statement queryStmt = realConnection.createStatement();
+        final ResultSet resultSet =
+                queryStmt.executeQuery("SELECT * FROM MULTI_COL_TABLE");
+
+        final ResultSetTableMetaData metaData =
+                new ResultSetTableMetaData("MULTI_COL_TABLE", resultSet, connection, true);
+        final Column[] columns = metaData.getColumns();
+
+        assertThat(columns).as("column count.").hasSize(3);
+        assertThat(columns[0].getColumnName()).as("column 0 name.").isEqualTo("ID");
+        assertThat(columns[1].getColumnName()).as("column 1 name.").isEqualTo("NAME");
+        assertThat(columns[2].getColumnName()).as("column 2 name.").isEqualTo("AMOUNT");
+    }
+
+    /**
+     * A non-{@link DefaultMetadataHandler} {@link IMetadataHandler}, so the fast path's
+     * exact-class safety valve in {@link ResultSetTableMetaData} does not apply and the legacy
+     * per-column path is exercised instead. Delegates to a real handler so results stay correct.
+     */
+    private static final class DelegatingMetadataHandler implements IMetadataHandler
+    {
+        private final IMetadataHandler delegate;
+
+        DelegatingMetadataHandler(IMetadataHandler delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        public ResultSet getColumns(DatabaseMetaData databaseMetaData, String schemaName,
+                String tableName) throws SQLException
+        {
+            return delegate.getColumns(databaseMetaData, schemaName, tableName);
+        }
+
+        public boolean matches(ResultSet resultSet, String schema, String table,
+                boolean caseSensitive) throws SQLException
+        {
+            return delegate.matches(resultSet, schema, table, caseSensitive);
+        }
+
+        public boolean matches(ResultSet resultSet, String catalog, String schema, String table,
+                String column, boolean caseSensitive) throws SQLException
+        {
+            return delegate.matches(resultSet, catalog, schema, table, column, caseSensitive);
+        }
+
+        public String getSchema(ResultSet resultSet) throws SQLException
+        {
+            return delegate.getSchema(resultSet);
+        }
+
+        public boolean tableExists(DatabaseMetaData databaseMetaData, String schemaName,
+                String tableName) throws SQLException
+        {
+            return delegate.tableExists(databaseMetaData, schemaName, tableName);
+        }
+
+        public ResultSet getTables(DatabaseMetaData databaseMetaData, String schemaName,
+                String[] tableTypes) throws SQLException
+        {
+            return delegate.getTables(databaseMetaData, schemaName, tableTypes);
+        }
+
+        public ResultSet getPrimaryKeys(DatabaseMetaData databaseMetaData, String schemaName,
+                String tableName) throws SQLException
+        {
+            return delegate.getPrimaryKeys(databaseMetaData, schemaName, tableName);
+        }
+    }
+
+}

--- a/src/test/java/org/dbunit/database/search/TablesDependencyHelperIT.java
+++ b/src/test/java/org/dbunit/database/search/TablesDependencyHelperIT.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.sql.Connection;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.TreeSet;
 
 import org.dbunit.AbstractDatabaseIT;
@@ -233,6 +234,77 @@ class TablesDependencyHelperIT extends AbstractDatabaseIT
         {
             DdlExecutor.dropTables(_connection.getConnection(), "C", "D", "E",
                     "A", "B", "F");
+            refreshConnection();
+        }
+    }
+
+    @Test
+    void testGetDirectDependentTables_withMultiHopChain_excludesTransitivePrerequisites()
+            throws Exception
+    {
+        DdlExecutor.dropTables(_connection.getConnection(), "B", "C", "E",
+                "H", "F", "G", "A", "D");
+        DdlExecutor.executeDdlFile(
+                TestUtils.getFile(
+                        "sql/" + ImportNodesFilterSearchCallbackIT.SQL_FILE),
+                _connection.getConnection(), false);
+        try
+        {
+            // Despite its name, getDirectDependentTables actually returns the tables
+            // the root's own FKs point to (its direct prerequisites), via
+            // ImportedKeysSearchCallback -- a longstanding, pre-existing naming quirk
+            // in this class, confirmed empirically, not introduced by this change.
+            // C's own FKs point directly to A and F; C reaches D only transitively,
+            // via A -> D (FKD). A direct-only (depth=1) query must exclude D.
+            final Set<String> actualOutput = TablesDependencyHelper
+                    .getDirectDependentTables(_connection, "C");
+
+            assertThat(actualOutput)
+                    .as("C's direct FK targets must be exactly {C, A, F}, "
+                            + "excluding D which is only reachable transitively via A.")
+                    .usingElementComparator(String.CASE_INSENSITIVE_ORDER)
+                    .containsExactlyInAnyOrder("C", "A", "F");
+        }
+        finally
+        {
+            DdlExecutor.dropTables(_connection.getConnection(), "B", "C", "E",
+                    "H", "F", "G", "A", "D");
+            refreshConnection();
+        }
+    }
+
+    @Test
+    void testGetDirectDependsOnTables_withMultiHopChain_excludesTransitiveDependents()
+            throws Exception
+    {
+        DdlExecutor.dropTables(_connection.getConnection(), "B", "C", "E",
+                "H", "F", "G", "A", "D");
+        DdlExecutor.executeDdlFile(
+                TestUtils.getFile(
+                        "sql/" + ImportNodesFilterSearchCallbackIT.SQL_FILE),
+                _connection.getConnection(), false);
+        try
+        {
+            // Despite its name, getDirectDependsOnTables actually returns the tables
+            // with a direct FK pointing at the root (its direct dependents), via
+            // ExportedKeysSearchCallback -- the same pre-existing naming quirk as
+            // above, in the opposite direction.
+            // C, E, and G each have a direct FKA pointing at A. B depends on A only
+            // transitively, via B -> C -> A (FKC then FKA). A direct-only (depth=1)
+            // query must exclude B.
+            final Set<String> actualOutput = TablesDependencyHelper
+                    .getDirectDependsOnTables(_connection, "A");
+
+            assertThat(actualOutput)
+                    .as("Tables with a direct FK to A must be exactly {A, C, E, G}, "
+                            + "excluding B which only depends on A transitively via C.")
+                    .usingElementComparator(String.CASE_INSENSITIVE_ORDER)
+                    .containsExactlyInAnyOrder("A", "C", "E", "G");
+        }
+        finally
+        {
+            DdlExecutor.dropTables(_connection.getConnection(), "B", "C", "E",
+                    "H", "F", "G", "A", "D");
             refreshConnection();
         }
     }

--- a/src/test/java/org/dbunit/dataset/AbstractTableMetaDataTest.java
+++ b/src/test/java/org/dbunit/dataset/AbstractTableMetaDataTest.java
@@ -21,12 +21,14 @@
 package org.dbunit.dataset;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.DatabaseMetaData;
 
+import org.dbunit.dataset.datatype.DataType;
 import org.dbunit.dataset.datatype.IDataTypeFactory;
 import org.dbunit.ext.mssql.MsSqlDataTypeFactory;
 import org.junit.jupiter.api.Test;
@@ -82,6 +84,82 @@ public class AbstractTableMetaDataTest
                 "Validation message should be null because DB product should be supported")
                 .isNull();
         verify(mockDatabaseMetData, times(1)).getDatabaseProductName();
+    }
+
+    @Test
+    void testGetColumnIndex_exactCaseName_returnsIndex() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("Name", DataType.VARCHAR),
+                new Column("Age", DataType.VARCHAR)};
+        final AbstractTableMetaData metaData = newMetaDataWithColumns(columns);
+
+        final int index = metaData.getColumnIndex("Age");
+
+        assertThat(index).as("Exact-case column name should resolve to its index.").isEqualTo(1);
+    }
+
+    @Test
+    void testGetColumnIndex_differentCaseName_returnsIndex() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("Name", DataType.VARCHAR),
+                new Column("Age", DataType.VARCHAR)};
+        final AbstractTableMetaData metaData = newMetaDataWithColumns(columns);
+
+        final int index = metaData.getColumnIndex("age");
+
+        assertThat(index)
+                .as("Different-case column name should fall through to the uppercase lookup.")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testGetColumnIndex_unknownName_throwsNoSuchColumnException() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("Name", DataType.VARCHAR)};
+        final AbstractTableMetaData metaData = newMetaDataWithColumns(columns);
+
+        assertThatExceptionOfType(NoSuchColumnException.class)
+                .as("Unknown column name should throw NoSuchColumnException.")
+                .isThrownBy(() -> metaData.getColumnIndex("UNKNOWN"));
+    }
+
+    @Test
+    void testGetColumnIndex_duplicateCaseInsensitiveNames_matchesUppercaseBehavior() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("a", DataType.VARCHAR),
+                new Column("A", DataType.VARCHAR)};
+        final AbstractTableMetaData metaData = newMetaDataWithColumns(columns);
+
+        final int exactCaseIndex = metaData.getColumnIndex("A");
+        final int otherCaseIndex = metaData.getColumnIndex("a");
+
+        assertThat(exactCaseIndex)
+                .as("Exact-case lookup must match the uppercase-path index for duplicate case-insensitive names.")
+                .isEqualTo(otherCaseIndex);
+    }
+
+    private AbstractTableMetaData newMetaDataWithColumns(final Column[] columns)
+    {
+        return new AbstractTableMetaData()
+        {
+            @Override
+            public Column[] getColumns() throws DataSetException
+            {
+                return columns;
+            }
+
+            @Override
+            public Column[] getPrimaryKeys() throws DataSetException
+            {
+                return new Column[0];
+            }
+
+            @Override
+            public String getTableName()
+            {
+                return "TEST_TABLE";
+            }
+        };
     }
 
 }

--- a/src/test/java/org/dbunit/dataset/ColumnsTest.java
+++ b/src/test/java/org/dbunit/dataset/ColumnsTest.java
@@ -173,6 +173,84 @@ class ColumnsTest
                 "column count (table=MY_TABLE, expectedColCount=3, actualColCount=2)");
     }
 
+    @Test
+    void testMergeColumnsByName_withDisjointColumns_returnsReferenceThenMergeColumnsInOrder()
+            throws Exception
+    {
+        final Column ref0 = new Column("c0", DataType.UNKNOWN);
+        final Column ref1 = new Column("c1", DataType.UNKNOWN);
+        final Column merge0 = new Column("c2", DataType.UNKNOWN);
+        final Column merge1 = new Column("c3", DataType.UNKNOWN);
+
+        final Column[] result = Columns.mergeColumnsByName(
+                new Column[] {ref0, ref1}, new Column[] {merge0, merge1});
+
+        assertThat(result).as("merged columns, reference first, in order.")
+                .containsExactly(ref0, ref1, merge0, merge1);
+    }
+
+    @Test
+    void testMergeColumnsByName_withOverlappingColumnName_keepsReferenceInstance()
+            throws Exception
+    {
+        final Column ref0 = new Column("c0", DataType.UNKNOWN);
+        // Same name as ref0, but a distinct instance with a different data type.
+        final Column duplicateOfRef0 = new Column("c0", DataType.VARCHAR);
+        final Column merge1 = new Column("c1", DataType.UNKNOWN);
+
+        final Column[] result = Columns.mergeColumnsByName(
+                new Column[] {ref0}, new Column[] {duplicateOfRef0, merge1});
+
+        assertThat(result)
+                .as("the reference column instance wins on a name collision.")
+                .containsExactly(ref0, merge1);
+    }
+
+    @Test
+    void testMergeColumnsByName_withEmptyReferenceColumns_returnsAllMergeColumns()
+            throws Exception
+    {
+        final Column merge0 = new Column("c0", DataType.UNKNOWN);
+        final Column merge1 = new Column("c1", DataType.UNKNOWN);
+
+        final Column[] result = Columns.mergeColumnsByName(new Column[0],
+                new Column[] {merge0, merge1});
+
+        assertThat(result).as("all merge columns returned when reference is empty.")
+                .containsExactly(merge0, merge1);
+    }
+
+    @Test
+    void testMergeColumnsByName_withEmptyColumnsToMerge_returnsReferenceColumns()
+            throws Exception
+    {
+        final Column ref0 = new Column("c0", DataType.UNKNOWN);
+        final Column ref1 = new Column("c1", DataType.UNKNOWN);
+
+        final Column[] result = Columns.mergeColumnsByName(
+                new Column[] {ref0, ref1}, new Column[0]);
+
+        assertThat(result).as("reference columns returned unchanged.")
+                .containsExactly(ref0, ref1);
+    }
+
+    @Test
+    void testMergeColumnsByName_withDuplicateNamesInColumnsToMerge_keepsBothInstances()
+            throws Exception
+    {
+        final Column ref0 = new Column("c0", DataType.UNKNOWN);
+        final Column merge0 = new Column("c1", DataType.UNKNOWN);
+        // Same name as merge0, neither present in the reference columns.
+        final Column merge1 = new Column("c1", DataType.VARCHAR);
+
+        final Column[] result = Columns.mergeColumnsByName(
+                new Column[] {ref0}, new Column[] {merge0, merge1});
+
+        assertThat(result)
+                .as("neither merge-side duplicate is deduplicated against the other.")
+                .containsExactly(ref0, merge0, merge1);
+    }
+
     private ITableMetaData createMetaData(final Column[] columns)
     {
         final DefaultTableMetaData tableMetaData =

--- a/src/test/java/org/dbunit/dataset/CompositeDataSetTest.java
+++ b/src/test/java/org/dbunit/dataset/CompositeDataSetTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import org.dbunit.dataset.datatype.DataType;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
 import org.dbunit.dataset.xml.XmlDataSet;
 import org.dbunit.testutil.TestUtils;
@@ -77,6 +78,44 @@ class CompositeDataSetTest extends AbstractDataSetTest
         assertThat(tableNames).as("table count combined").hasSize(2);
         assertThat(tableNames[0]).isEqualTo("DUPLICATE_TABLE");
         assertThat(tableNames[1]).isEqualTo("EMPTY_TABLE");
+    }
+
+    @Test
+    void testConstructor_threePartsSameTable_valuesReadableAcrossAllParts() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("ID", DataType.NUMERIC)};
+
+        final DefaultTable part1 = new DefaultTable("T", columns);
+        part1.addRow(new Object[] {Integer.valueOf(1)});
+        part1.addRow(new Object[] {Integer.valueOf(2)});
+
+        final DefaultTable part2 = new DefaultTable("T", columns);
+        part2.addRow(new Object[] {Integer.valueOf(3)});
+
+        final DefaultTable part3 = new DefaultTable("T", columns);
+        part3.addRow(new Object[] {Integer.valueOf(4)});
+        part3.addRow(new Object[] {Integer.valueOf(5)});
+
+        final CompositeDataSet dataSet =
+                new CompositeDataSet(new ITable[] {part1, part2, part3});
+        final ITable combined = dataSet.getTable("T");
+
+        assertThat(combined.getRowCount())
+                .as("row count should equal the sum of all three parts.")
+                .isEqualTo(5);
+
+        final Object[] expected = {Integer.valueOf(1), Integer.valueOf(2),
+                Integer.valueOf(3), Integer.valueOf(4), Integer.valueOf(5)};
+        for (int i = 0; i < expected.length; i++)
+        {
+            assertThat(combined.getValue(i, "ID"))
+                    .as("value at row " + i + " should be readable across all three parts.")
+                    .isEqualTo(expected[i]);
+        }
+
+        assertThat(combined.getTableMetaData())
+                .as("metadata should be taken from the first part.")
+                .isSameAs(part1.getTableMetaData());
     }
 
     private CompositeDataSet createCompositeDataSet(final boolean combined,

--- a/src/test/java/org/dbunit/dataset/ReplacementTableTest.java
+++ b/src/test/java/org/dbunit/dataset/ReplacementTableTest.java
@@ -22,9 +22,11 @@ package org.dbunit.dataset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.time.Duration;
 
 import org.dbunit.Assertion;
 import org.dbunit.dataset.datatype.DataType;
@@ -330,6 +332,27 @@ class ReplacementTableTest extends AbstractTableTest
         expectedTable.addRow(expectedRow);
 
         Assertion.assertEquals(expectedTable, actualTable);
+    }
+
+    @Test
+    void testSubstringReplacement_withEmptyStringSubstring_doesNotHang() throws Exception
+    {
+        final String tableName = "TABLE_NAME";
+        final Column[] columns = new Column[] {new Column("VALUE", DataType.CHAR)};
+
+        final DefaultTable originalTable = new DefaultTable(tableName, columns);
+        originalTable.addRow(new Object[] {"some value"});
+        final ReplacementTable actualTable = new ReplacementTable(originalTable);
+        actualTable.addReplacementSubstring("", "replacement");
+
+        final Object result = assertTimeoutPreemptively(Duration.ofSeconds(5),
+                () -> actualTable.getValue(0, "VALUE"),
+                "Registering an empty-string substring replacement must not hang.");
+
+        assertThat(result)
+                .as("An empty-string substring has no occurrences to replace, so the value "
+                        + "should be returned unchanged.")
+                .isEqualTo("some value");
     }
 
     @Test

--- a/src/test/java/org/dbunit/dataset/RowFilterTableTest.java
+++ b/src/test/java/org/dbunit/dataset/RowFilterTableTest.java
@@ -1,6 +1,7 @@
 package org.dbunit.dataset;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.dbunit.dataset.filter.IRowFilter;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
@@ -56,5 +57,37 @@ class RowFilterTableTest
                 .isEqualTo("row 2 col 0");
         assertThat(rowFilterTable.getValue(2, "COLUMN0"))
                 .isEqualTo("row 3 col 0");
+    }
+
+    @Test
+    void testGetValue_withRowIndexAtOrAboveRowCount_throwsRowOutOfBoundsException()
+            throws Exception
+    {
+        final ITable testTable = getDataSet().getTable("TEST_TABLE");
+        final IRowFilter acceptNone = rowValueProvider -> false;
+        final ITable rowFilterTable = new RowFilterTable(testTable, acceptNone);
+
+        assertThat(rowFilterTable.getRowCount()).as("row count.").isZero();
+        assertThatExceptionOfType(RowOutOfBoundsException.class)
+                .as("accessing row 0 of an empty filtered table.")
+                .isThrownBy(() -> rowFilterTable.getValue(0, "COLUMN0"));
+    }
+
+    @Test
+    void testRowFilter_withNoRowsFilteredOut_returnsAllRowsInOriginalOrder()
+            throws Exception
+    {
+        final ITable testTable = getDataSet().getTable("TEST_TABLE");
+        final IRowFilter acceptAll = rowValueProvider -> true;
+        final ITable rowFilterTable = new RowFilterTable(testTable, acceptAll);
+
+        assertThat(rowFilterTable.getRowCount()).as("row count.")
+                .isEqualTo(testTable.getRowCount());
+        for (int row = 0; row < testTable.getRowCount(); row++)
+        {
+            assertThat(rowFilterTable.getValue(row, "COLUMN0"))
+                    .as("value at row " + row + ".")
+                    .isEqualTo(testTable.getValue(row, "COLUMN0"));
+        }
     }
 }

--- a/src/test/java/org/dbunit/dataset/RowOutOfBoundsExceptionTest.java
+++ b/src/test/java/org/dbunit/dataset/RowOutOfBoundsExceptionTest.java
@@ -1,0 +1,53 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit.dataset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeff Jensen
+ * @since 3.2.1
+ */
+class RowOutOfBoundsExceptionTest
+{
+    @Test
+    void testFillInStackTrace_newInstance_hasEmptyStackTrace() throws Exception
+    {
+        final RowOutOfBoundsException exception = new RowOutOfBoundsException();
+
+        assertThat(exception.getStackTrace())
+                .as("End-of-rows control-flow exception should not capture a stack trace.")
+                .isEmpty();
+    }
+
+    @Test
+    void testGetMessage_constructedWithMessage_preservesMessage() throws Exception
+    {
+        final RowOutOfBoundsException exception = new RowOutOfBoundsException("row 42 is out of bounds");
+
+        assertThat(exception.getMessage())
+                .as("Message passed to the constructor should still be available via getMessage().")
+                .isEqualTo("row 42 is out of bounds");
+    }
+
+}

--- a/src/test/java/org/dbunit/dataset/SortedTableTest.java
+++ b/src/test/java/org/dbunit/dataset/SortedTableTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.dbunit.dataset.datatype.DataType;
+import org.dbunit.dataset.datatype.TypeCastException;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
 import org.dbunit.testutil.TestUtils;
 import org.junit.jupiter.api.Test;
@@ -221,6 +222,162 @@ public class SortedTableTest extends AbstractTableTest
         assertThat(actualSortColumn.getDataType()).isEqualTo(DataType.UNKNOWN);
         assertThat(actualSortColumn.getColumnName()).isEqualTo("COLUMN2");
         assertThat(actualSortColumn.getNullable()).isEqualTo(Column.NULLABLE);
+    }
+
+    @Test
+    void testSort_nullValuesInSortColumnByStringMode_sortsNullsFirst() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("COL0", DataType.VARCHAR)};
+        final DefaultTable table = new DefaultTable("NULL_ORDER_TABLE", columns);
+        table.addRow(new Object[] {"b"});
+        table.addRow(new Object[] {null});
+        table.addRow(new Object[] {"a"});
+
+        final SortedTable sortedTable = new SortedTable(table, new String[] {"COL0"});
+
+        final Object[] expected = {null, "a", "b"};
+        for (int i = 0; i < sortedTable.getRowCount(); i++)
+        {
+            assertThat(sortedTable.getValue(i, "COL0")).as("value row " + i + ".")
+                    .isEqualTo(expected[i]);
+        }
+    }
+
+    @Test
+    void testSort_nullValuesInSortColumnComparableMode_sortsNullsFirst() throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("COL0", DataType.NUMERIC)};
+        final DefaultTable table = new DefaultTable("NULL_ORDER_TABLE", columns);
+        table.addRow(new Object[] {Integer.valueOf(2)});
+        table.addRow(new Object[] {null});
+        table.addRow(new Object[] {Integer.valueOf(1)});
+
+        final SortedTable sortedTable = new SortedTable(table, new String[] {"COL0"});
+        sortedTable.setUseComparable(true);
+
+        final Object[] expected = {null, Integer.valueOf(1), Integer.valueOf(2)};
+        for (int i = 0; i < sortedTable.getRowCount(); i++)
+        {
+            assertThat(sortedTable.getValue(i, "COL0")).as("value row " + i + ".")
+                    .isEqualTo(expected[i]);
+        }
+    }
+
+    @Test
+    void testGetValue_sortTriggered_readsEachSortCellOnce() throws Exception
+    {
+        final int rowCount = 5;
+        final Column[] columns = new Column[] {new Column("COL0", DataType.VARCHAR),
+                new Column("COL1", DataType.VARCHAR), new Column("COL2", DataType.VARCHAR)};
+        final DefaultTable table = new DefaultTable("PERF_TABLE", columns);
+        for (int i = 0; i < rowCount; i++)
+        {
+            table.addRow(new Object[] {String.valueOf(rowCount - i), "b" + i, "c" + i});
+        }
+        final CountingTable countingTable = new CountingTable(table);
+
+        final SortedTable sortedTable =
+                new SortedTable(countingTable, new String[] {"COL0", "COL1"});
+        // Trigger the lazy sort-key precompute. This getValue call also reads one additional
+        // cell -- the actually-requested value -- on top of the precompute itself.
+        sortedTable.getValue(0, "COL0");
+
+        final int sortColumnCount = sortedTable.getSortColumns().length;
+        final int expectedCalls = rowCount * sortColumnCount + 1;
+        assertThat(countingTable.getValueCallCount())
+                .as("Sorting should read each (row, sort column) cell exactly once during the precompute, "
+                        + "plus one call for the actually-requested cell.")
+                .isEqualTo(expectedCalls);
+    }
+
+    @Test
+    void testGetValue_customComparatorSubclassOverride_isNotBypassedByPrecompute()
+            throws Exception
+    {
+        final Column[] columns = new Column[] {new Column("COL0", DataType.VARCHAR)};
+        final DefaultTable table = new DefaultTable("REVERSED_TABLE", columns);
+        table.addRow(new Object[] {"a"});
+        table.addRow(new Object[] {"c"});
+        table.addRow(new Object[] {"b"});
+
+        final SortedTable sortedTable =
+                new SortedTable(table, new String[] {"COL0"});
+        // ReverseOrderComparator is a subclass of the built-in RowComparatorByString,
+        // installed through the public setRowComparator() extension point. The
+        // precomputed-key fast path must be gated by exact class, not instanceof,
+        // or this override is silently bypassed and the table sorts in the built-in
+        // (ascending) order instead of the subclass's overridden (descending) order.
+        sortedTable.setRowComparator(
+                new ReverseOrderComparator(table, sortedTable.getSortColumns()));
+
+        final Object[] actual = {sortedTable.getValue(0, "COL0"),
+                sortedTable.getValue(1, "COL0"), sortedTable.getValue(2, "COL0")};
+
+        assertThat(actual)
+                .as("A RowComparatorByString subclass installed via setRowComparator() "
+                        + "must have its overridden compare() honored, sorting "
+                        + "descending instead of the built-in ascending order.")
+                .containsExactly("c", "b", "a");
+    }
+
+    /**
+     * Subclass of the built-in string comparator, overriding {@code compare} to sort
+     * descending instead of ascending -- used to prove the precomputed-key fast path
+     * does not silently bypass a caller-supplied comparator's overridden behavior.
+     */
+    private static final class ReverseOrderComparator
+            extends SortedTable.RowComparatorByString
+    {
+        private ReverseOrderComparator(final ITable table, final Column[] sortColumns)
+        {
+            super(table, sortColumns);
+        }
+
+        @Override
+        protected int compare(final Column column, final Object value1,
+                final Object value2) throws TypeCastException
+        {
+            return -super.compare(column, value1, value2);
+        }
+    }
+
+    /**
+     * {@link ITable} decorator counting {@link #getValue(int, String)} calls, to prove the
+     * sort precompute reads each (row, sort column) cell exactly once.
+     */
+    private static final class CountingTable implements ITable
+    {
+        private final ITable delegate;
+        private int valueCallCount;
+
+        private CountingTable(final ITable delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        int getValueCallCount()
+        {
+            return valueCallCount;
+        }
+
+        @Override
+        public ITableMetaData getTableMetaData()
+        {
+            return delegate.getTableMetaData();
+        }
+
+        @Override
+        public int getRowCount()
+        {
+            return delegate.getRowCount();
+        }
+
+        @Override
+        public Object getValue(final int row, final String columnName) throws DataSetException
+        {
+            valueCallCount++;
+            return delegate.getValue(row, columnName);
+        }
     }
 
 }

--- a/src/test/java/org/dbunit/dataset/csv/CsvDataSetWriterTest.java
+++ b/src/test/java/org/dbunit/dataset/csv/CsvDataSetWriterTest.java
@@ -1,13 +1,21 @@
 package org.dbunit.dataset.csv;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.sql.Clob;
+import java.sql.SQLException;
 
 import org.dbunit.Assertion;
 import org.dbunit.dataset.CachedDataSet;
+import org.dbunit.dataset.DataSetBuilder;
 import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.stream.DataSetProducerAdapter;
 import org.dbunit.testutil.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +56,64 @@ class CsvDataSetWriterTest
         final CsvDataSetWriter writer = new CsvDataSetWriter(dest);
         producer.setConsumer(writer);
         producer.produce();
+    }
+
+    @Test
+    void testWrite_multiRowTable_writesCompleteFile() throws Exception
+    {
+        final String dest = "target/csv/multi-row-out";
+        final int rowCount = 2000;
+        final DataSetBuilder.TableBuilder builder = new DataSetBuilder().table("MULTI_ROW")
+                .columns("ID", "NAME");
+        for (int i = 0; i < rowCount; i++)
+        {
+            builder.row(i, "name-" + i);
+        }
+        final IDataSet expected = builder.build();
+
+        new File(dest).delete();
+        CsvDataSetWriter.write(expected, new File(dest));
+        final IDataSet actual = produceToMemory(dest);
+
+        assertThat(actual.getTable("MULTI_ROW").getRowCount())
+                .as("All rows should be present after the buffered writer is closed.")
+                .isEqualTo(rowCount);
+        Assertion.assertEquals(expected, actual);
+    }
+
+    @Test
+    void testWrite_laterRowFailsTypeCast_earlierRowsAlreadyFlushedToDisk()
+            throws Exception
+    {
+        final String dest = "target/csv/flush-on-error-out";
+        final Clob unreadableClob = mock(Clob.class);
+        when(unreadableClob.length())
+                .thenThrow(new SQLException("cannot read CLOB length"));
+
+        final IDataSet dataSet = new DataSetBuilder().table("FLUSH_ON_ERROR")
+                .columns("ID", "VALUE")
+                .row(1, "row one, written before the failure")
+                .row(2, unreadableClob)
+                .build();
+
+        new File(dest).mkdirs();
+        final File tableFile = new File(dest, "FLUSH_ON_ERROR.csv");
+        tableFile.delete();
+
+        final CsvDataSetWriter writer = new CsvDataSetWriter(dest);
+        final DataSetProducerAdapter producer = new DataSetProducerAdapter(dataSet);
+        producer.setConsumer(writer);
+
+        assertThrows(DataSetException.class, producer::produce,
+                "Row 2's unreadable CLOB should fail the write.");
+
+        final String writtenContent =
+                new String(Files.readAllBytes(tableFile.toPath()));
+        assertThat(writtenContent)
+                .as("Row 1, written to the buffered writer before row 2 failed, "
+                        + "must have been flushed to disk despite the overall "
+                        + "write failing without ever reaching endTable().")
+                .contains("row one, written before the failure");
     }
 
     @Test

--- a/src/test/java/org/dbunit/dataset/datatype/TimestampDataTypeTest.java
+++ b/src/test/java/org/dbunit/dataset/datatype/TimestampDataTypeTest.java
@@ -21,6 +21,7 @@
 package org.dbunit.dataset.datatype;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -288,6 +289,17 @@ class TimestampDataTypeTest extends AbstractDataTypeTest
         assertThat(THIS_TYPE.typeCast(dateString))
                 .as("date-only string without timezone should parse as local-timezone midnight.")
                 .isEqualTo(expected);
+    }
+
+    @Test
+    void testTypeCast_withStringShorterThanTimezoneSuffixMinimumLength_throwsTypeCastException()
+            throws Exception
+    {
+        assertThatExceptionOfType(TypeCastException.class)
+                .as("A string shorter than the minimum possible timezone-suffix length "
+                        + "must still throw TypeCastException, not an index exception, "
+                        + "when the cheap timezone-suffix gate skips the regex.")
+                .isThrownBy(() -> THIS_TYPE.typeCast("a"));
     }
 
     @Test

--- a/src/test/java/org/dbunit/dataset/excel/XlsDataSetTest.java
+++ b/src/test/java/org/dbunit/dataset/excel/XlsDataSetTest.java
@@ -27,6 +27,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import org.dbunit.Assertion;
 import org.dbunit.dataset.AbstractDataSetTest;
@@ -37,6 +39,8 @@ import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
 import org.dbunit.testutil.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * @author Manuel Laflamme
@@ -125,6 +129,34 @@ class XlsDataSetTest extends AbstractDataSetTest
         } finally
         {
             tempFile.delete();
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void testConstructor_withFile_closesUnderlyingFileStream() throws Exception
+    {
+        // Windows-only: proving stream closure via deletability relies on Windows' mandatory
+        // file locking, where an open FileInputStream blocks File.delete(). On Linux/macOS,
+        // unlink() succeeds regardless of open file descriptors, so this same assertion would
+        // pass even with the leak still present -- it would not be a meaningful regression guard
+        // there.
+        final File sourceFile = TestUtils.getFile("xml/dataSetTest.xls");
+        final File tempCopy = File.createTempFile("xlsDataSetTest", ".xls");
+        try
+        {
+            Files.copy(sourceFile.toPath(), tempCopy.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+
+            new XlsDataSet(tempCopy);
+
+            assertThat(tempCopy.delete())
+                    .as("the file should be deletable immediately after construction, "
+                            + "proving the internal FileInputStream was closed rather than leaked.")
+                    .isTrue();
+        } finally
+        {
+            tempCopy.delete();
         }
     }
 

--- a/src/test/java/org/dbunit/dataset/excel/XlsDataSetWriterTest.java
+++ b/src/test/java/org/dbunit/dataset/excel/XlsDataSetWriterTest.java
@@ -1,14 +1,21 @@
 package org.dbunit.dataset.excel;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 
+import org.apache.poi.ss.usermodel.Workbook;
+import org.dbunit.dataset.DataSetBuilder;
 import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.IDataSet;
 import org.junit.jupiter.api.Test;
@@ -41,5 +48,25 @@ class XlsDataSetWriterTest
         final FileOutputStream outputStream =
                 new FileOutputStream(OUTPUT_EXCEL_FILE);
         assertDoesNotThrow(() -> XlsDataSet.write(dataSet, outputStream));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testWrite_afterCompletion_releasesWorkbookStyles() throws Exception
+    {
+        final IDataSet dataSet = new DataSetBuilder().table("T")
+                .columns("AMOUNT").row(new BigDecimal("1.50")).build();
+
+        final XlsDataSetWriter writer = new XlsDataSetWriter();
+        writer.write(dataSet, new ByteArrayOutputStream());
+
+        final Field field =
+                XlsDataSetWriter.class.getDeclaredField("cellStyleMap");
+        field.setAccessible(true);
+        final Map<Workbook, Map> cellStyleMap = (Map<Workbook, Map>) field.get(null);
+
+        assertThat(cellStyleMap)
+                .as("cellStyleMap should not retain any workbook's cell styles after write() returns.")
+                .isEmpty();
     }
 }

--- a/src/test/java/org/dbunit/dataset/excel/XlsTableTest.java
+++ b/src/test/java/org/dbunit/dataset/excel/XlsTableTest.java
@@ -23,8 +23,16 @@ package org.dbunit.dataset.excel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.TimeZone;
 
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.dbunit.dataset.AbstractTableTest;
 import org.dbunit.dataset.Column;
 import org.dbunit.dataset.IDataSet;
@@ -172,6 +180,46 @@ public class XlsTableTest extends AbstractTableTest
             final Object actual = table.getValue(row, columnName).toString();
             assertThat(actual).as(columns[i].getColumnName())
                     .isEqualTo(expected[i]);
+        }
+    }
+
+    @Test
+    void testGetValue_manyNumericCellsSameFormat_returnsSameValuesAsUncached() throws Exception
+    {
+        final DecimalFormatSymbols symbols = new DecimalFormatSymbols();
+        symbols.setDecimalSeparator('.');
+        final String formatString = "0.00";
+
+        final Workbook workbook = new XSSFWorkbook();
+        final Sheet sheet = workbook.createSheet("NUMERIC_SHEET");
+        final CellStyle style = workbook.createCellStyle();
+        style.setDataFormat(workbook.createDataFormat().getFormat(formatString));
+
+        final Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("AMOUNT");
+
+        final int rowCount = 50;
+        for (int i = 0; i < rowCount; i++)
+        {
+            final Row row = sheet.createRow(i + 1);
+            final Cell cell = row.createCell(0);
+            cell.setCellValue(i + 0.125);
+            cell.setCellStyle(style);
+        }
+
+        final XlsTable table = new XlsTable("NUMERIC_SHEET", sheet);
+
+        for (int i = 0; i < rowCount; i++)
+        {
+            final BigDecimal expected = new BigDecimal(
+                    new DecimalFormat(formatString, symbols).format(i + 0.125));
+
+            final Object actual = table.getValue(i, "AMOUNT");
+
+            assertThat(actual)
+                    .as("row " + i
+                            + " cached DecimalFormat result should match the uncached result.")
+                    .isEqualTo(expected);
         }
     }
 }

--- a/src/test/java/org/dbunit/dataset/xml/FlatXmlProducerTest.java
+++ b/src/test/java/org/dbunit/dataset/xml/FlatXmlProducerTest.java
@@ -25,11 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Locale;
 
 import org.dbunit.dataset.Column;
 import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.DefaultDataSet;
 import org.dbunit.dataset.DefaultTable;
+import org.dbunit.dataset.datatype.DataType;
 import org.dbunit.dataset.stream.AbstractProducerTest;
 import org.dbunit.dataset.stream.IDataSetProducer;
 import org.dbunit.dataset.stream.MockDataSetConsumer;
@@ -210,6 +212,105 @@ class FlatXmlProducerTest extends AbstractProducerTest
                 "Should not be here!");
 
         consumer.verify();
+    }
+
+    @Test
+    void testProduce_newColumnAppearsMidTable_columnSensed() throws Exception
+    {
+        final String tableName = "TABLE_NAME";
+        final MockDataSetConsumer consumer = new MockDataSetConsumer();
+        consumer.addExpectedStartDataSet();
+        // Column sensing runs through a BufferedConsumer, which replays startTable/row
+        // once with the final, fully-merged metadata rather than forwarding the
+        // intermediate per-row startTable calls FlatXmlProducer issues internally.
+        consumer.addExpectedStartTable(tableName,
+                new Column[] {new Column("COL0", DataType.UNKNOWN),
+                        new Column("COL1", DataType.UNKNOWN)});
+        consumer.addExpectedRow(tableName, new Object[] {"value0", null});
+        consumer.addExpectedRow(tableName,
+                new Object[] {"value0b", "value1b"});
+        consumer.addExpectedEndTable(tableName);
+        consumer.addExpectedEndDataSet();
+
+        // No DTD, column sensing enabled: COL1 first appears on the second row.
+        final String content = "<?xml version=\"1.0\"?>" + "<dataset>"
+                + "<TABLE_NAME COL0=\"value0\"/>"
+                + "<TABLE_NAME COL0=\"value0b\" COL1=\"value1b\"/>"
+                + "</dataset>";
+        final InputSource source = new InputSource(new StringReader(content));
+        final IDataSetProducer producer =
+                new FlatXmlProducer(source, false, true);
+        producer.setConsumer(consumer);
+
+        producer.produce();
+        consumer.verify();
+    }
+
+    @Test
+    void testProduce_columnSensingDisabled_missingColumnIgnored() throws Exception
+    {
+        final String tableName = "TABLE_NAME";
+        final MockDataSetConsumer consumer = new MockDataSetConsumer();
+        consumer.addExpectedStartDataSet();
+        consumer.addExpectedStartTable(tableName,
+                new Column[] {new Column("COL0", DataType.UNKNOWN)});
+        consumer.addExpectedRow(tableName, new Object[] {"value0"});
+        // COL1 on the second row is not part of the metadata and column sensing is
+        // disabled, so it must be ignored rather than merged or thrown.
+        consumer.addExpectedRow(tableName, new Object[] {"value0b"});
+        consumer.addExpectedEndTable(tableName);
+        consumer.addExpectedEndDataSet();
+
+        final String content = "<?xml version=\"1.0\"?>" + "<dataset>"
+                + "<TABLE_NAME COL0=\"value0\"/>"
+                + "<TABLE_NAME COL0=\"value0b\" COL1=\"value1b\"/>"
+                + "</dataset>";
+        final InputSource source = new InputSource(new StringReader(content));
+        final IDataSetProducer producer =
+                new FlatXmlProducer(source, false, false);
+        producer.setConsumer(consumer);
+
+        producer.produce();
+        consumer.verify();
+    }
+
+    @Test
+    void testProduce_turkishLocaleAndCaseVariantColumnName_recognizesSameColumn() throws Exception
+    {
+        final Locale originalLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+        try
+        {
+            final String tableName = "TABLE_NAME";
+            final MockDataSetConsumer consumer = new MockDataSetConsumer();
+            consumer.addExpectedStartDataSet();
+            consumer.addExpectedStartTable(tableName,
+                    new Column[] {new Column("id", DataType.UNKNOWN)});
+            consumer.addExpectedRow(tableName, new Object[] {"1"});
+            consumer.addExpectedRow(tableName, new Object[] {"2"});
+            consumer.addExpectedEndTable(tableName);
+            consumer.addExpectedEndDataSet();
+
+            // Row 2's "ID" is the same logical column as row 1's "id", just differently
+            // cased. Under the Turkish default locale, "id".toUpperCase() produces a
+            // dotted capital I ("İD") that does not equal "ID".toUpperCase() ("ID"),
+            // so a locale-sensitive comparison would wrongly treat row 2's ID as a new,
+            // unrelated column instead of recognizing it as "id".
+            final String content = "<?xml version=\"1.0\"?>" + "<dataset>"
+                    + "<TABLE_NAME id=\"1\"/>" + "<TABLE_NAME ID=\"2\"/>"
+                    + "</dataset>";
+            final InputSource source = new InputSource(new StringReader(content));
+            final IDataSetProducer producer =
+                    new FlatXmlProducer(source, false, true);
+            producer.setConsumer(consumer);
+
+            producer.produce();
+            consumer.verify();
+        }
+        finally
+        {
+            Locale.setDefault(originalLocale);
+        }
     }
 
 }

--- a/src/test/java/org/dbunit/dataset/yaml/YmlDataSetTest.java
+++ b/src/test/java/org/dbunit/dataset/yaml/YmlDataSetTest.java
@@ -22,6 +22,8 @@ package org.dbunit.dataset.yaml;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -30,6 +32,7 @@ import java.io.OutputStream;
 
 import org.dbunit.Assertion;
 import org.dbunit.dataset.AbstractDataSetTest;
+import org.dbunit.dataset.DataSetBuilder;
 import org.dbunit.dataset.DataSetUtils;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
@@ -139,6 +142,30 @@ class YmlDataSetTest extends AbstractDataSetTest
         {
             tempFile.delete();
         }
+    }
+
+    @Test
+    void testWrite_largeDataSetToMemoryStream_writesCompleteOutput() throws Exception
+    {
+        final int rowCount = 2000;
+        final DataSetBuilder.TableBuilder builder =
+                new DataSetBuilder().table("MANY_ROWS").columns("ID", "NAME");
+        for (int i = 0; i < rowCount; i++)
+        {
+            builder.row(i, "name-" + i);
+        }
+        final IDataSet expectedDataSet = builder.build();
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        YamlDataSet.write(expectedDataSet, out);
+
+        final IDataSet actualDataSet =
+                new YamlDataSet(new ByteArrayInputStream(out.toByteArray()));
+
+        assertThat(actualDataSet.getTable("MANY_ROWS").getRowCount())
+                .as("All rows should be present in the in-memory stream after write() returns.")
+                .isEqualTo(rowCount);
+        Assertion.assertEquals(expectedDataSet, actualDataSet);
     }
 
 }

--- a/src/test/java/org/dbunit/util/SQLHelperTest.java
+++ b/src/test/java/org/dbunit/util/SQLHelperTest.java
@@ -22,6 +22,7 @@
 package org.dbunit.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,6 +31,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import org.dbunit.AbstractHSQLTestCase;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +61,9 @@ class SQLHelperTest extends AbstractHSQLTestCase
     @Mock
     private ResultSet mockCatalogsResultSet;
 
+    @Mock
+    private ResultSet mockPrimaryKeysResultSet;
+
     @BeforeEach
     protected void setUp() throws Exception
     {
@@ -80,6 +85,65 @@ class SQLHelperTest extends AbstractHSQLTestCase
             assertThat(actualPK).as(
                     "primary key column for table " + table + " does not match")
                     .isEqualTo(expectedPK);
+        }
+    }
+
+    @Test
+    void testGetPrimaryKeyColumn_withMockedResultSet_closesResultSet() throws SQLException
+    {
+        when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
+        when(mockDatabaseMetaData.getPrimaryKeys(null, null, "A"))
+                .thenReturn(mockPrimaryKeysResultSet);
+        when(mockPrimaryKeysResultSet.next()).thenReturn(true);
+        when(mockPrimaryKeysResultSet.getString(4)).thenReturn("PKA");
+
+        final String actualPK = SQLHelper.getPrimaryKeyColumn(mockConnection, "A");
+
+        assertThat(actualPK).as("primary key column.").isEqualTo("PKA");
+        verify(mockPrimaryKeysResultSet, times(1)).close();
+    }
+
+    @Test
+    void testGetPrimaryKeyColumn_withNoPrimaryKey_throwsSQLExceptionAndClosesResultSet()
+            throws SQLException
+    {
+        when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
+        when(mockDatabaseMetaData.getPrimaryKeys(null, null, "NOPK"))
+                .thenReturn(mockPrimaryKeysResultSet);
+        when(mockPrimaryKeysResultSet.next()).thenReturn(false);
+
+        assertThatExceptionOfType(SQLException.class)
+                .as("a table with no primary key should raise a clear error instead of "
+                        + "an invalid-cursor error from an unconsumed empty ResultSet.")
+                .isThrownBy(() -> SQLHelper.getPrimaryKeyColumn(mockConnection, "NOPK"))
+                .withMessageContaining("NOPK");
+        verify(mockPrimaryKeysResultSet, times(1)).close();
+    }
+
+    @Test
+    void testGetPrimaryKeyColumn_withRealNoPkTable_throwsSQLException() throws SQLException
+    {
+        final Connection conn = getConnection().getConnection();
+        assertThat(conn).as("didn't get a connection").isNotNull();
+
+        try (Statement stmt = conn.createStatement())
+        {
+            stmt.execute("CREATE TABLE NOPK_TABLE (COL1 INT)");
+
+            assertThatExceptionOfType(SQLException.class)
+                    .as("a real table with no primary key should raise a clear "
+                            + "error, not an invalid-cursor error from an unconsumed "
+                            + "empty ResultSet, confirming the mocked-ResultSet "
+                            + "coverage above matches genuine driver behavior.")
+                    .isThrownBy(() -> SQLHelper.getPrimaryKeyColumn(conn, "NOPK_TABLE"))
+                    .withMessageContaining("NOPK_TABLE");
+        }
+        finally
+        {
+            try (Statement stmt = conn.createStatement())
+            {
+                stmt.execute("DROP TABLE NOPK_TABLE");
+            }
         }
     }
 

--- a/src/test/java/org/dbunit/util/search/BiDirectionalEdgesDepthFirstSearchTest.java
+++ b/src/test/java/org/dbunit/util/search/BiDirectionalEdgesDepthFirstSearchTest.java
@@ -23,6 +23,8 @@ package org.dbunit.util.search;
 
 import java.util.SortedSet;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * @author Felipe Leme (dbunit@felipeal.net)
  * @version $Revision$
@@ -66,6 +68,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
     // using unidirectional edges.
     // For, instance, on the graph C->A->B, C would never be reached from A or B
 
+    @Test
     public void testSingleReverseEdge() throws Exception
     {
         setInput(new String[] {A});
@@ -75,6 +78,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testSingleReverseEdgeInputB() throws Exception
     {
         setInput(new String[] {B});
@@ -84,6 +88,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testSingleReverseEdgeMultipleInput() throws Exception
     {
         setInput(new String[] {B, A});
@@ -93,6 +98,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testSingleReverseEdgeMultipleInputIncludingC() throws Exception
     {
         setInput(new String[] {C, B, A});
@@ -102,6 +108,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testOneInputTwoEdges() throws Exception
     {
         setInput(new String[] {B});
@@ -113,28 +120,29 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
 
     // TODO: continue adding more tests uncommenting and adapting tests below...
     /*
-     * 
+     *
      * public void testSingleEdgeRepeatedInput() throws Exception { setInput(new
      * String[] { A, B, B, A, B }); addEdges(A, new String[] { B });
      * setOutput(new String[] { B, A }); doIt(); }
-     * 
+     *
      * public void testDisconnected() throws Exception { setInput(new String[] {
      * A, C }); addEdges(A, new String[] { B }); setOutput(new String[] { B, A,
      * C }); doIt(); }
-     * 
+     *
      * public void testDisconnectedInverseOrder() throws Exception {
      * setInput(new String[] { C, A }); addEdges(A, new String[] { B });
      * setOutput(new String[] { B, A, C }); doIt(); }
-     * 
+     *
      * public void testMultipleEdgesOneSource() throws Exception { setInput(new
      * String[] { A }); addEdges(A, new String[] { B, C }); setOutput(new
      * String[] { B, C, A }); doIt(); }
-     * 
+     *
      * public void testMultipleEdgesMultipleSources() throws Exception {
      * setInput(new String[] { A }); addEdges(A, new String[] { B, C });
      * addEdges(B, new String[] { D, C }); setOutput(new String[] { C, D, B, A
      * }); doIt(); }
      */
+    @Test
     public void testMultipleEdgesCycleFromA() throws Exception
     {
         setInput(new String[] {A});
@@ -145,6 +153,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesCycleFromB() throws Exception
     {
         setInput(new String[] {B});
@@ -155,6 +164,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesCycleFromBA() throws Exception
     {
         setInput(new String[] {B, A});
@@ -169,8 +179,9 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
      * public void testSelfCyclic() throws Exception { setInput(new String[] { A
      * }); addEdges(A, new String[] { A }); setOutput(new String[] { A });
      * doIt(); }
-     * 
+     *
      */
+    @Test
     public void testCyclicAndSelfCyclic() throws Exception
     {
         setInput(new String[] {A});
@@ -181,6 +192,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testDisconnectedCycles() throws Exception
     {
         setInput(new String[] {A, D});
@@ -194,6 +206,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testConnectedCycle() throws Exception
     {
         setInput(new String[] {A});
@@ -206,6 +219,7 @@ public class BiDirectionalEdgesDepthFirstSearchTest extends DepthFirstSearchTest
         doIt();
     }
 
+    @Test
     public void testBigConnectedCycle() throws Exception
     {
         setInput(new String[] {A});

--- a/src/test/java/org/dbunit/util/search/DepthFirstSearchTest.java
+++ b/src/test/java/org/dbunit/util/search/DepthFirstSearchTest.java
@@ -21,6 +21,8 @@
 
 package org.dbunit.util.search;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * @author Felipe Leme (dbunit@felipeal.net)
  * @version $Revision$
@@ -30,11 +32,13 @@ package org.dbunit.util.search;
 public class DepthFirstSearchTest extends AbstractSearchTestCase
 {
 
+    @Test
     public void testEmptyGraph() throws Exception
     {
         doIt();
     }
 
+    @Test
     public void testSingleNode() throws Exception
     {
         setInput(new String[] {A});
@@ -42,6 +46,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdge() throws Exception
     {
         setInput(new String[] {A});
@@ -50,6 +55,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeMultipleInput() throws Exception
     {
         setInput(new String[] {A, B});
@@ -58,6 +64,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeRepeatedInput() throws Exception
     {
         setInput(new String[] {A, B, B, A, B});
@@ -66,6 +73,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnected() throws Exception
     {
         setInput(new String[] {A, C});
@@ -74,6 +82,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnectedInverseOrder() throws Exception
     {
         setInput(new String[] {C, A});
@@ -82,6 +91,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesOneSource() throws Exception
     {
         setInput(new String[] {A});
@@ -90,6 +100,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesMultipleSources() throws Exception
     {
         setInput(new String[] {A});
@@ -99,6 +110,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesCycleFromA() throws Exception
     {
         setInput(new String[] {A});
@@ -109,6 +121,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesCycleFromB() throws Exception
     {
         setInput(new String[] {B});
@@ -119,6 +132,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testMultipleEdgesCycleFromBA() throws Exception
     {
         setInput(new String[] {B, A});
@@ -129,6 +143,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSelfCyclic() throws Exception
     {
         setInput(new String[] {A});
@@ -137,6 +152,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testCyclicAndSelfCyclic() throws Exception
     {
         setInput(new String[] {A});
@@ -147,6 +163,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnectedCycles() throws Exception
     {
         setInput(new String[] {A, D});
@@ -160,6 +177,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testConnectedCycle() throws Exception
     {
         setInput(new String[] {A});
@@ -172,6 +190,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testBigConnectedCycle() throws Exception
     {
         setInput(new String[] {A});
@@ -184,6 +203,7 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testMerge() throws Exception
     {
         setInput(new String[] {A, C});

--- a/src/test/java/org/dbunit/util/search/DepthFirstSearchTest.java
+++ b/src/test/java/org/dbunit/util/search/DepthFirstSearchTest.java
@@ -21,6 +21,10 @@
 
 package org.dbunit.util.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -211,6 +215,49 @@ public class DepthFirstSearchTest extends AbstractSearchTestCase
         addEdges(C, new String[] {A});
         setOutput(new String[] {B, A, C});
         doIt();
+    }
+
+    @Test
+    void testSearch_depthLimitOne_returnsOnlyDirectNodes() throws Exception
+    {
+        setInput(new String[] {A});
+        addEdges(A, new String[] {B});
+        addEdges(B, new String[] {C});
+
+        final Set actual = new DepthFirstSearch(1).search(fInput, getCallback());
+
+        assertThat(actual)
+                .as("Depth-limited search of 1 on A->B->C from {A} should include the direct dependency B but not the transitive dependency C.")
+                .containsExactlyInAnyOrder(A, B);
+    }
+
+    @Test
+    void testSearch_depthLimitOne_multipleChildren_allDirectIncluded() throws Exception
+    {
+        setInput(new String[] {A});
+        addEdges(A, new String[] {B, C});
+        addEdges(B, new String[] {D});
+
+        final Set actual = new DepthFirstSearch(1).search(fInput, getCallback());
+
+        assertThat(actual)
+                .as("Depth-limited search of 1 from A with two direct children B and C should include both, and not B's child D.")
+                .containsExactlyInAnyOrder(A, B, C);
+    }
+
+    @Test
+    void testSearch_depthLimitTwo_stopsAtGrandchildren() throws Exception
+    {
+        setInput(new String[] {A});
+        addEdges(A, new String[] {B});
+        addEdges(B, new String[] {C});
+        addEdges(C, new String[] {D});
+
+        final Set actual = new DepthFirstSearch(2).search(fInput, getCallback());
+
+        assertThat(actual)
+                .as("Depth-limited search of 2 on A->B->C->D from {A} should reach the grandchild C but not the great-grandchild D.")
+                .containsExactlyInAnyOrder(A, B, C);
     }
 
 }

--- a/src/test/java/org/dbunit/util/search/ExcludeNodesSearchCallbackTest.java
+++ b/src/test/java/org/dbunit/util/search/ExcludeNodesSearchCallbackTest.java
@@ -23,6 +23,8 @@ package org.dbunit.util.search;
 
 import java.util.SortedSet;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * @author Felipe Leme (dbunit@felipeal.net)
  * @version $Revision$
@@ -52,13 +54,15 @@ public class ExcludeNodesSearchCallbackTest extends AbstractSearchTestCase
 
     }
 
-    public void testSingleNode() throws Exception
+    @Test
+    void testSingleNode() throws Exception
     {
         setInput(new String[] {A});
         setDenied(new String[] {A});
         doIt();
     }
 
+    @Test
     public void testSingleEdgeDeniedA() throws Exception
     {
         setInput(new String[] {A});
@@ -67,6 +71,7 @@ public class ExcludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeDeniedB() throws Exception
     {
         setInput(new String[] {A});
@@ -76,6 +81,7 @@ public class ExcludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeMultipleInputDeniedB() throws Exception
     {
         setInput(new String[] {A, B});
@@ -85,6 +91,7 @@ public class ExcludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeMultipleInputDeniedA() throws Exception
     {
         setInput(new String[] {A, B});
@@ -94,6 +101,7 @@ public class ExcludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnected() throws Exception
     {
         setInput(new String[] {A, C});
@@ -103,6 +111,7 @@ public class ExcludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnectedAllowedC() throws Exception
     {
         setInput(new String[] {A, C});

--- a/src/test/java/org/dbunit/util/search/IncludeNodesSearchCallbackTest.java
+++ b/src/test/java/org/dbunit/util/search/IncludeNodesSearchCallbackTest.java
@@ -23,6 +23,8 @@ package org.dbunit.util.search;
 
 import java.util.SortedSet;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * @author Felipe Leme (dbunit@felipeal.net)
  * @version $Revision$
@@ -52,6 +54,7 @@ public class IncludeNodesSearchCallbackTest extends AbstractSearchTestCase
 
     }
 
+    @Test
     public void testSingleNode() throws Exception
     {
         setInput(new String[] {A});
@@ -60,6 +63,7 @@ public class IncludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeAllowedA() throws Exception
     {
         setInput(new String[] {A});
@@ -69,6 +73,7 @@ public class IncludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeAllowedB() throws Exception
     {
         setInput(new String[] {A});
@@ -77,6 +82,7 @@ public class IncludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testSingleEdgeMultipleInputAllowedB() throws Exception
     {
         setInput(new String[] {A, B});
@@ -86,6 +92,7 @@ public class IncludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnected() throws Exception
     {
         setInput(new String[] {A, C});
@@ -95,6 +102,7 @@ public class IncludeNodesSearchCallbackTest extends AbstractSearchTestCase
         doIt();
     }
 
+    @Test
     public void testDisconnectedAllowedC() throws Exception
     {
         setInput(new String[] {A, C});

--- a/src/test/java/org/dbunit/util/xml/XmlWriterTest.java
+++ b/src/test/java/org/dbunit/util/xml/XmlWriterTest.java
@@ -206,4 +206,25 @@ class XmlWriterTest
         final String actualXml = writer.toString();
         assertThat(actualXml).isEqualTo(expectedXml);
     }
+
+    @Test
+    void testClose_bufferedUnderlyingWriter_flushesAllContent() throws Exception
+    {
+        final StringWriter writer = new StringWriter();
+        final XmlWriter xmlWriter = new XmlWriter(writer);
+        xmlWriter.enablePrettyPrint(false);
+        final int elementCount = 2000;
+
+        final StringBuilder expectedXml = new StringBuilder();
+        for (int i = 0; i < elementCount; i++)
+        {
+            xmlWriter.writeEmptyElement("ROW" + i);
+            expectedXml.append("<ROW").append(i).append("/>");
+        }
+        xmlWriter.close();
+
+        assertThat(writer.toString())
+                .as("All buffered XML output should be flushed to the underlying writer after close().")
+                .isEqualTo(expectedXml.toString());
+    }
 }


### PR DESCRIPTION
## Summary

Implements the 28-item plan in `performance-improvements.adoc` (26 items landed, 2 investigated and not completed — see below). Two root causes accounted for most of the found cost: per-cell column-name-to-index string allocation (`AbstractTableMetaData.getColumnIndex`) and exception-terminated table scans capturing full stack traces (`RowOutOfBoundsException`); both are fixed once, centrally (WI-01, WI-02). The rest are localized hotspots: JDBC metadata round-trips, unbuffered I/O, quadratic/linear-scan algorithms, and per-cell allocation in hot loops.

* **Tier 1 (WI-01–06)** — quick wins: central allocation fixes, output buffering (XML/CSV/DTD/YAML), format caching.
* **Tier 2 (WI-07–12)** — higher-risk items: revived `DepthFirstSearch` tests that had silently stopped running under JUnit Jupiter, fixed the depth-limit bug that exposed (WI-08, **behavior change**: "direct dependency" queries no longer include transitive tables), cached `DatabaseSequenceFilter` dependency edges and replaced its sort with a proper topological sort, single-query column metadata fetch in `ResultSetTableMetaData` (issue 617 — re-fixes a patch that was reverted in this repo's history for breaking Oracle; this version is scoped to `DefaultMetadataHandler` only and verified against `oracle-18`/`oracle-23`), precomputed sort keys in `SortedTable`.
* **Tier 3 (WI-13–19)** — hot-loop cleanups plus two defect fixes: unclosed `ResultSet`s in `PrimaryKeyFilter`, a `XlsDataSetWriter` cell-style memory leak.
* **Tier 4 (WI-20–27)** — minor/optional: guarded debug logging, more leak fixes (`SQLHelper`, `QueryTableIterator`, `XlsDataSet`), algorithmic cleanups in `CsvParserImpl`/`OrderedTableNameMap`/`RowFilterTable`/`Columns.mergeColumnsByName`.

**Not completed** — see `performance-improvements.adoc`'s "Not Completed" section, and issues #782 / #787, for full reasoning:
* **WI-23 / #782** — the planned `WorkbookFactory.create(File)` switch was skipped: `XlsTable` reads cells lazily from the POI `Sheet` for the table's whole lifetime, so closing the `Workbook` early isn't safe. A separate, unrelated leak found along the way (`XlsDataSet(File)`'s own never-closed `FileInputStream`) was fixed and filed as #788.
* **WI-28 / #787** — skipped entirely: its target callers (`DataSetProducerAdapter`, `RefreshOperation`, `AbstractBatchOperation`) generically scan `ITable`s that may be `ForwardOnlyResultSetTable`, whose `getRowCount()` always throws `UnsupportedOperationException` — bounding scans by row count would break that supported streaming configuration.

Every commit is one atomic change (production code + tests + `changes.xml` entry), references its GitHub issue, and was verified against all 9 database profiles (`hsqldb-2-7`, `h2-1-4`, `derby-10-14`, `postgresql-16`, `mysql-9-20`, `mssql-2022`, `oracle-18`, `oracle-23`, `db2-11-5`) via the `build-any-branch-with-all-dbs.yml` workflow.

## Test plan

- [x] Full unit suite green throughout (final state: 1691 tests, 0 failures/errors)
- [x] All 9 database profiles' integration tests green via CI for every commit
- [x] `./mvnw clean install site` run and japicmp report reviewed: zero binary/source API incompatibilities
- [x] WI-08's behavior change and WI-11's Oracle-safety scoping specifically verified against `oracle-18`/`oracle-23`
- [x] WI-23's leak fix verified with a Windows-specific test (file deletable immediately after construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwPJgmyWJqWJYrCgQscryv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved dependency-based table ordering using topological sorting with cached JDBC key lookups.
  * Faster metadata/column handling via caching, precomputed sort keys, and reduced per-cell work.
  * Reduced allocations by optimizing row filtering, column merging, replacements, and numeric/date formatting.
* **Bug Fixes**
  * Better JDBC/resource handling and eliminated spurious stack traces.
  * Writer reliability improved: buffered CSV/XML/YAML/DTD/Flat XML outputs are flushed on write failures.
  * Added a safe `flush()` to the XML writer for partially written documents.
* **Tests**
  * Expanded coverage for ordering, depth-limited searches, metadata resolution, filtering/sorting, and regression/write behavior.
* **Documentation**
  * Updated changelog release description and contribution guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->