### PR TITLE
perf(database): Extend column-metadata cache to MySqlMetadataHandler and Db2MetadataHandler

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names, primitive row index storage in RowFilterTable, set-based membership in Columns.mergeColumnsByName">
+    <release version="3.2.1-SNAPSHOT" date="June 4, 2026" description="Speed up column index lookups, suppress RowOutOfBoundsException stack traces, buffer XML, CSV, DTD, and YAML output, cache DecimalFormat in XlsTable, restore DepthFirstSearch tests, fix DepthFirstSearch depth limit, cache DatabaseSequenceFilter dependency edges, topological sort in DatabaseSequenceFilter, single column-metadata fetch in ResultSetTableMetaData, precompute sort keys in SortedTable, reduce assertion loop overhead, reduce ReplacementTable scanning, flatten CompositeDataSet table merging, detect columns without exception flow in FlatXmlProducer, fix PrimaryKeyFilter result set leak, fix XlsDataSetWriter memory leak, skip timezone regex for plain timestamps, guard hot-path debug logging, fix SQLHelper result set leak, reuse query metadata in QueryTableIterator, fix XlsDataSet file stream leak, release consumed CSV rows early, lookup map for OrderedTableNameMap original names, primitive row index storage in RowFilterTable, set-based membership in Columns.mergeColumnsByName, extend ResultSetTableMetaData column-metadata cache to MySqlMetadataHandler and Db2MetadataHandler">
       <!-- dependabot:dep=actions/checkout:new=7:pr=756 -->
       <action dev="dependabot" type="update" due-to="Dependabot">Update github_actions dependency actions/checkout from 6 to 7 (#756).</action>
       <!-- dependabot:dep=org.apache.maven.plugins:maven-failsafe-plugin:new=3.5.6:pr=748 -->
@@ -122,6 +122,9 @@
       </action>
       <action dev="jeffjensen" type="update" issue="786" system="github" due-to="jeffjensen">
           Replace the O(n*m^2) nested scan and List.remove(Object) in Columns.mergeColumnsByName with set-based membership.
+      </action>
+      <action dev="jeffjensen" type="update" issue="792" system="github" due-to="jeffjensen">
+          Extend ResultSetTableMetaData's per-table column-metadata cache to MySqlMetadataHandler and Db2MetadataHandler via a new IMetadataHandler.matchesColumn()/supportsColumnCache() capability, instead of only DefaultMetadataHandler.
       </action>
     </release>
     <release version="3.2.0" date="June 4, 2026" description="GH action updates, extract UTs from ITs, rename test methods, add DataSetBuilder, improve test infra, improve UT coverage, bump HSQLDB, improve IT coverage, fix table lookup with case-sensitive databases, fix metadata table name lookups, convert UTs to ITs, OracleSdoGeometryDataType test coverage, fix ScrollableResultSetTable, document profile unsupportedFeatures, correct profile unsupportedFeatures, configure DB2, fix SQLHelper NPE, fix TruncateTableOperation for DB2">

--- a/src/main/java/org/dbunit/database/DefaultMetadataHandler.java
+++ b/src/main/java/org/dbunit/database/DefaultMetadataHandler.java
@@ -151,16 +151,27 @@ public class DefaultMetadataHandler implements IMetadataHandler {
         return metaData.getTables(null, schemaName, "%", tableType);
     }
 
-    public ResultSet getPrimaryKeys(DatabaseMetaData metaData, String schemaName, String tableName) 
+    public ResultSet getPrimaryKeys(DatabaseMetaData metaData, String schemaName, String tableName)
     throws SQLException
     {
         if(logger.isTraceEnabled())
-            logger.trace("getPrimaryKeys(metaData={}, schemaName={}, tableName={}) - start", 
+            logger.trace("getPrimaryKeys(metaData={}, schemaName={}, tableName={}) - start",
                     new Object[] {metaData, schemaName, tableName} );
 
         ResultSet resultSet = metaData.getPrimaryKeys(
                 null, schemaName, tableName);
         return resultSet;
+    }
+
+    /**
+     * {@inheritDoc}
+     * The inherited default {@code matchesColumn(...)} already mirrors this class's
+     * {@link #matches(ResultSet, String, String, String, String, boolean)}, so the cache fast
+     * path is safe to use.
+     */
+    public boolean supportsColumnCache()
+    {
+        return true;
     }
 
 }

--- a/src/main/java/org/dbunit/database/IMetadataHandler.java
+++ b/src/main/java/org/dbunit/database/IMetadataHandler.java
@@ -24,6 +24,8 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.dbunit.util.SQLHelper;
+
 /**
  * Handler to specify the behavior for a lookup of column metadata using database metadata.
  * 
@@ -126,5 +128,56 @@ public interface IMetadataHandler
     public ResultSet getPrimaryKeys(DatabaseMetaData databaseMetaData, String schemaName, String tableName)
     throws SQLException;
 
+    /**
+     * Tests whether a candidate column's metadata values match the search criteria, using the
+     * same semantics as {@link #matches(ResultSet, String, String, String, String, boolean)} but
+     * operating on already-extracted values instead of a live {@link ResultSet} row. This lets a
+     * caller that batch-fetches and caches {@code DatabaseMetaData#getColumns} rows (see
+     * {@code ResultSetTableMetaData}) replay this handler's matching rules against a cached row
+     * without re-querying or holding a {@link ResultSet} open.
+     * <p>
+     * The default implementation mirrors {@link DefaultMetadataHandler}'s matching rules. A
+     * handler whose {@link #matches(ResultSet, String, String, String, String, boolean)} override
+     * differs must override this method the same way, and override
+     * {@link #supportsColumnCache()} to return {@code true}.
+     * @param searchCatalog The catalog to search for. If <code>null</code> or empty it is ignored in the comparison.
+     * @param actualCatalog The candidate row's catalog.
+     * @param searchSchema The schema to search for. If <code>null</code> or empty it is ignored in the comparison.
+     * @param actualSchema The candidate row's schema.
+     * @param searchTable The table to search for. If <code>null</code> or empty it is ignored in the comparison.
+     * @param actualTable The candidate row's table.
+     * @param searchColumn The column to search for. If <code>null</code> or empty it is ignored in the comparison.
+     * @param actualColumn The candidate row's column.
+     * @param caseSensitive Whether or not the comparison should be case sensitive.
+     * @return <code>true</code> if the candidate's values match the search criteria.
+     * @since 3.2.1
+     */
+    default boolean matchesColumn(String searchCatalog, String actualCatalog,
+            String searchSchema, String actualSchema, String searchTable, String actualTable,
+            String searchColumn, String actualColumn, boolean caseSensitive)
+    {
+        return SQLHelper.areEqualIgnoreNull(searchCatalog, actualCatalog, caseSensitive)
+                && SQLHelper.areEqualIgnoreNull(searchSchema, actualSchema, caseSensitive)
+                && SQLHelper.areEqualIgnoreNull(searchTable, actualTable, caseSensitive)
+                && SQLHelper.areEqualIgnoreNull(searchColumn, actualColumn, caseSensitive);
+    }
+
+    /**
+     * Whether {@code ResultSetTableMetaData}'s per-table column-metadata cache may safely use
+     * {@link #matchesColumn(String, String, String, String, String, String, String, String, boolean)}
+     * in place of the row-by-row {@link #matches(ResultSet, String, String, String, String, boolean)}
+     * scan for this handler.
+     * <p>
+     * Returns {@code false} by default, so a custom {@link IMetadataHandler} whose
+     * {@code matches(...)} override is not also replicated in {@code matchesColumn(...)} keeps
+     * the legacy per-column behavior. Override to return {@code true} only alongside a
+     * {@code matchesColumn(...)} override that fully replicates this handler's matching semantics.
+     * @return <code>true</code> if this handler's cache fast path is safe to use.
+     * @since 3.2.1
+     */
+    default boolean supportsColumnCache()
+    {
+        return false;
+    }
 
 }

--- a/src/main/java/org/dbunit/database/ResultSetTableMetaData.java
+++ b/src/main/java/org/dbunit/database/ResultSetTableMetaData.java
@@ -152,11 +152,12 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
         ResultSetMetaData metaData = resultSet.getMetaData();
         Column[] columns = new Column[metaData.getColumnCount()];
         // Fast-path cache of one getColumns() result per distinct (schema, table) origin, so a
-        // multi-column table is not re-queried once per column. Only safe for the exact
-        // DefaultMetadataHandler class (not instanceof: e.g. Db2MetadataHandler extends it but
-        // overrides matches() with DB2-specific catalog handling that this cache bypasses) --
-        // custom/ext handlers keep the legacy per-column path below.
-        Map columnsByOrigin = columnFactory.getClass() == DefaultMetadataHandler.class
+        // multi-column table is not re-queried once per column. Only safe for a handler that
+        // declares supportsColumnCache() true, meaning its matchesColumn(...) override (if any)
+        // fully replicates its matches(...) semantics -- a custom handler that overrides
+        // matches(...) without also overriding matchesColumn(...)/supportsColumnCache() keeps the
+        // legacy per-column path below by inheriting the interface's conservative false default.
+        Map columnsByOrigin = columnFactory.supportsColumnCache()
                 ? new HashMap()
                 : null;
         for (int i = 0; i < columns.length; i++)
@@ -312,18 +313,19 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
     /**
      * Looks up a column's metadata from the per-(schema, table)-origin cache, lazily fetching
      * and caching a whole table's columns (via a single {@code getColumns} call) on first need.
-     * Candidates are bucketed by {@link Locale#ENGLISH}-uppercased column name, then filtered by
-     * exact-case column name (only when {@link #_caseSensitiveMetaData} is set) and by catalog
-     * and table, using the same {@link SQLHelper#areEqualIgnoreNull(String, String, boolean)}
-     * semantics as the legacy {@code matches(...)} path -- a null/empty search catalog matches
-     * any row. The table check matters because {@code metadataHandler.getColumns} passes
-     * {@code tableName} to JDBC's {@code DatabaseMetaData#getColumns} as a LIKE pattern, not an
-     * exact match: a table name containing {@code _} or {@code %} (e.g. {@code USER_ACCOUNT})
-     * can make the driver also return columns from an unrelated, differently-named table whose
-     * name happens to match that pattern (e.g. {@code USERXACCOUNT}). The first remaining
-     * candidate, in {@code getColumns} row order, wins, consistent with a forward-scanning
-     * {@code scrollTo} match stopping at the first hit. A miss returns <code>null</code>, exactly
-     * like the not-found branch of the legacy per-column path.
+     * Candidates are bucketed by {@link Locale#ENGLISH}-uppercased column name, then filtered via
+     * {@link IMetadataHandler#matchesColumn(String, String, String, String, String, String,
+     * String, String, boolean)}, so a handler's own catalog/schema matching quirks (see e.g.
+     * {@code Db2MetadataHandler}, {@code MySqlMetadataHandler}) are replayed exactly as the
+     * legacy {@code matches(...)} path would apply them. The table check matters because
+     * {@code metadataHandler.getColumns} passes {@code tableName} to JDBC's
+     * {@code DatabaseMetaData#getColumns} as a LIKE pattern, not an exact match: a table name
+     * containing {@code _} or {@code %} (e.g. {@code USER_ACCOUNT}) can make the driver also
+     * return columns from an unrelated, differently-named table whose name happens to match that
+     * pattern (e.g. {@code USERXACCOUNT}). The first remaining candidate, in {@code getColumns}
+     * row order, wins, consistent with a forward-scanning {@code scrollTo} match stopping at the
+     * first hit. A miss returns <code>null</code>, exactly like the not-found branch of the
+     * legacy per-column path.
      */
     private Column createColumnFromCache(Map columnsByOrigin, DatabaseMetaData databaseMetaData,
             IMetadataHandler metadataHandler, String catalogName, String schemaName, String tableName,
@@ -346,15 +348,10 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
         for (Iterator it = candidates.iterator(); it.hasNext();)
         {
             ColumnMetaData data = (ColumnMetaData) it.next();
-            if (_caseSensitiveMetaData && !data.columnName.equals(columnName))
-            {
-                continue;
-            }
-            if (!SQLHelper.areEqualIgnoreNull(catalogName, data.catalogName, _caseSensitiveMetaData))
-            {
-                continue;
-            }
-            if (!SQLHelper.areEqualIgnoreNull(tableName, data.tableName, _caseSensitiveMetaData))
+            boolean matches = metadataHandler.matchesColumn(catalogName, data.catalogName,
+                    schemaName, data.schemaName, tableName, data.tableName, columnName,
+                    data.columnName, _caseSensitiveMetaData);
+            if (!matches)
             {
                 continue;
             }
@@ -465,6 +462,7 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
     private static final class ColumnMetaData
     {
         private final String catalogName;
+        private final String schemaName;
         private final String tableName;
         private final String columnName;
         private final int sqlType;
@@ -475,11 +473,12 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
         private final String isAutoIncrement;
         private final String isGenerated;
 
-        private ColumnMetaData(String catalogName, String tableName, String columnName, int sqlType,
-                String sqlTypeName, int nullable, String remarks, String columnDefaultValue,
+        private ColumnMetaData(String catalogName, String schemaName, String tableName, String columnName,
+                int sqlType, String sqlTypeName, int nullable, String remarks, String columnDefaultValue,
                 String isAutoIncrement, String isGenerated)
         {
             this.catalogName = catalogName;
+            this.schemaName = schemaName;
             this.tableName = tableName;
             this.columnName = columnName;
             this.sqlType = sqlType;
@@ -494,11 +493,13 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
         /**
          * Reads the same {@code getColumns} result set columns, by the same indexes, as
          * {@link SQLHelper#createColumn(ResultSet, IDataTypeFactory, boolean)}, plus
-         * {@code TABLE_CAT} so cache candidates can be matched by catalog too.
+         * {@code TABLE_CAT} and {@code TABLE_SCHEM} so cache candidates can be matched by
+         * catalog and schema too (see {@link IMetadataHandler#matchesColumn}).
          */
         private static ColumnMetaData readFrom(ResultSet resultSet) throws SQLException
         {
             String catalogName = resultSet.getString(1);
+            String schemaName = resultSet.getString(2);
             String tableName = resultSet.getString(3);
             String columnName = resultSet.getString(4);
             int sqlType = resultSet.getInt(5);
@@ -514,8 +515,8 @@ public class ResultSetTableMetaData extends AbstractTableMetaData
             String isAutoIncrement = resultSet.getString(23);
             // some JDBC drivers do not have this column even though they claim to be compliant with JDBC 4.1 or later
             String isGenerated = resultSet.getMetaData().getColumnCount() >= 24 ? resultSet.getString(24) : null;
-            return new ColumnMetaData(catalogName, tableName, columnName, sqlType, sqlTypeName, nullable,
-                    remarks, columnDefaultValue, isAutoIncrement, isGenerated);
+            return new ColumnMetaData(catalogName, schemaName, tableName, columnName, sqlType, sqlTypeName,
+                    nullable, remarks, columnDefaultValue, isAutoIncrement, isGenerated);
         }
 
         /**

--- a/src/main/java/org/dbunit/ext/db2/Db2MetadataHandler.java
+++ b/src/main/java/org/dbunit/ext/db2/Db2MetadataHandler.java
@@ -110,4 +110,31 @@ public class Db2MetadataHandler extends DefaultMetadataHandler {
         return SQLHelper.areEqualIgnoreNull(value1, value2, caseSensitive);
     }
 
+    /**
+     * {@inheritDoc}
+     * Mirrors {@link #matches(ResultSet, String, String, String, String, boolean)}'s
+     * catalog-mismatch tolerance, using {@link #areEqualIgnoreBothNull(String, String, boolean)}
+     * for the catalog comparison instead of the inherited default's
+     * {@link SQLHelper#areEqualIgnoreNull(String, String, boolean)}.
+     */
+    public boolean matchesColumn(String searchCatalog, String actualCatalog,
+            String searchSchema, String actualSchema, String searchTable, String actualTable,
+            String searchColumn, String actualColumn, boolean caseSensitive)
+    {
+        return areEqualIgnoreBothNull(searchCatalog, actualCatalog, caseSensitive)
+                && areEqualIgnoreNull(searchSchema, actualSchema, caseSensitive)
+                && areEqualIgnoreNull(searchTable, actualTable, caseSensitive)
+                && areEqualIgnoreNull(searchColumn, actualColumn, caseSensitive);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return <code>true</code>, since {@link #matchesColumn} replicates this class's
+     * {@link #matches(ResultSet, String, String, String, String, boolean)} semantics.
+     */
+    public boolean supportsColumnCache()
+    {
+        return true;
+    }
+
 }

--- a/src/main/java/org/dbunit/ext/mysql/MySqlMetadataHandler.java
+++ b/src/main/java/org/dbunit/ext/mysql/MySqlMetadataHandler.java
@@ -126,16 +126,49 @@ public class MySqlMetadataHandler implements IMetadataHandler {
         return metaData.getTables(schemaName, null, "%", tableType);
     }
 
-    public ResultSet getPrimaryKeys(DatabaseMetaData metaData, String schemaName, String tableName) 
+    public ResultSet getPrimaryKeys(DatabaseMetaData metaData, String schemaName, String tableName)
     throws SQLException
     {
         if(logger.isTraceEnabled())
-            logger.trace("getPrimaryKeys(metaData={}, schemaName={}, tableName={}) - start", 
+            logger.trace("getPrimaryKeys(metaData={}, schemaName={}, tableName={}) - start",
                     new Object[] {metaData, schemaName, tableName} );
 
         ResultSet resultSet = metaData.getPrimaryKeys(
                 schemaName, null, tableName);
         return resultSet;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Mirrors {@link #matches(ResultSet, String, String, String, String, boolean)}'s
+     * catalog/schema swap: MySQL's {@code getColumns} rows report only a catalog, not a schema,
+     * so when the search side expects a schema but the row has none, the row's catalog is
+     * compared against the searched schema instead.
+     */
+    public boolean matchesColumn(String searchCatalog, String actualCatalog,
+            String searchSchema, String actualSchema, String searchTable, String actualTable,
+            String searchColumn, String actualColumn, boolean caseSensitive)
+    {
+        if(searchSchema != null && actualSchema == null && searchCatalog == null && actualCatalog != null){
+            logger.debug("Switching catalog/schema because the are mutually null");
+            actualSchema = actualCatalog;
+            actualCatalog = null;
+        }
+
+        return areEqualIgnoreNull(searchCatalog, actualCatalog, caseSensitive) &&
+            areEqualIgnoreNull(searchSchema, actualSchema, caseSensitive) &&
+            areEqualIgnoreNull(searchTable, actualTable, caseSensitive) &&
+            areEqualIgnoreNull(searchColumn, actualColumn, caseSensitive);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return <code>true</code>, since {@link #matchesColumn} replicates this class's
+     * {@link #matches(ResultSet, String, String, String, String, boolean)} semantics.
+     */
+    public boolean supportsColumnCache()
+    {
+        return true;
     }
 
 }

--- a/src/test/java/org/dbunit/database/ResultSetTableMetaDataTest.java
+++ b/src/test/java/org/dbunit/database/ResultSetTableMetaDataTest.java
@@ -35,6 +35,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.dbunit.dataset.Column;
+import org.dbunit.ext.db2.Db2MetadataHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -90,6 +91,34 @@ class ResultSetTableMetaDataTest
                 .isEqualToIgnoringCase("NAME");
         assertThat(columns[2].getColumnName()).as("column 2 name.")
                 .isEqualToIgnoringCase("AMOUNT");
+
+        verify(spyMetaData, times(1)).getColumns(any(), any(), eq("MULTI_COL_TABLE"), eq("%"));
+    }
+
+    @Test
+    void testCreateMetaData_db2MetadataHandler_singleGetColumnsQuery() throws Exception
+    {
+        final Connection realConnection = InMemoryDatabaseConnection.create().getConnection();
+        final Statement ddlStmt = realConnection.createStatement();
+        ddlStmt.execute(CREATE_TABLE_SQL);
+        ddlStmt.close();
+
+        final DatabaseMetaData spyMetaData = spy(realConnection.getMetaData());
+        final Connection spyConnection = spy(realConnection);
+        when(spyConnection.getMetaData()).thenReturn(spyMetaData);
+        connection = new DatabaseConnection(spyConnection);
+        connection.getConfig().setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER,
+                new Db2MetadataHandler());
+
+        final Statement queryStmt = spyConnection.createStatement();
+        final ResultSet resultSet =
+                queryStmt.executeQuery("SELECT * FROM MULTI_COL_TABLE");
+
+        final ResultSetTableMetaData metaData =
+                new ResultSetTableMetaData("MULTI_COL_TABLE", resultSet, connection, false);
+        final Column[] columns = metaData.getColumns();
+
+        assertThat(columns).as("column count.").hasSize(3);
 
         verify(spyMetaData, times(1)).getColumns(any(), any(), eq("MULTI_COL_TABLE"), eq("%"));
     }

--- a/src/test/java/org/dbunit/ext/db2/Db2MetadataHandlerTest.java
+++ b/src/test/java/org/dbunit/ext/db2/Db2MetadataHandlerTest.java
@@ -1,0 +1,105 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit.ext.db2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for {@link Db2MetadataHandler}, focused on the catalog-mismatch tolerance in
+ * {@link Db2MetadataHandler#matches(ResultSet, String, String, String, String, boolean)} and its
+ * value-based {@link Db2MetadataHandler#matchesColumn} counterpart.
+ *
+ * @since 3.2.1
+ */
+class Db2MetadataHandlerTest
+{
+    private final Db2MetadataHandler handler = new Db2MetadataHandler();
+
+    @ParameterizedTest
+    @MethodSource("provideCatalogSchemaTableColumnCombinations")
+    void testMatchesColumn_variousCatalogSchemaTableColumnCombinations_agreesWithResultSetBasedMatches(
+            String searchCatalog, String actualCatalog, String searchSchema, String actualSchema,
+            String searchTable, String actualTable, String searchColumn, String actualColumn,
+            boolean caseSensitive) throws SQLException
+    {
+        final ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString(1)).thenReturn(actualCatalog);
+        when(resultSet.getString(2)).thenReturn(actualSchema);
+        when(resultSet.getString(3)).thenReturn(actualTable);
+        when(resultSet.getString(4)).thenReturn(actualColumn);
+
+        final boolean viaResultSet = handler.matches(resultSet, searchCatalog, searchSchema,
+                searchTable, searchColumn, caseSensitive);
+        final boolean viaValues = handler.matchesColumn(searchCatalog, actualCatalog, searchSchema,
+                actualSchema, searchTable, actualTable, searchColumn, actualColumn, caseSensitive);
+
+        assertThat(viaValues)
+                .as("matchesColumn(...) must agree with matches(ResultSet, ...) for this combination.")
+                .isEqualTo(viaResultSet);
+    }
+
+    private static Stream<Arguments> provideCatalogSchemaTableColumnCombinations()
+    {
+        return Stream.of(
+                Arguments.of("CAT", "CAT", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of("CAT", "OTHER_CAT", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of(null, "CAT", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of("", "", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of("CAT", "CAT", "SCHEMA", "WRONG_SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of("CAT", "CAT", "SCHEMA", "SCHEMA", "TABLE", "WRONG_TABLE", "COL", "COL", false),
+                Arguments.of("CAT", "CAT", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "WRONG_COL", false),
+                Arguments.of("CAT", "CAT", "SCHEMA", "schema", "TABLE", "table", "COL", "col", false),
+                Arguments.of("CAT", "CAT", "SCHEMA", "schema", "TABLE", "table", "COL", "col", true));
+    }
+
+    /**
+     * DB2's catalog comparison is a no-op except when both the searched and actual catalog are
+     * literally the empty string (see {@link Db2MetadataHandler#matches}'s javadoc for the
+     * driver quirk this works around), so a mismatched, non-empty catalog on either side must
+     * never fail the match on its own.
+     */
+    @ParameterizedTest
+    @MethodSource("provideMismatchedCatalogs")
+    void testMatchesColumn_withMismatchedNonEmptyCatalogsButOtherwiseMatching_returnsTrue(
+            String searchCatalog, String actualCatalog)
+    {
+        final boolean matches = handler.matchesColumn(searchCatalog, actualCatalog, "SCHEMA",
+                "SCHEMA", "TABLE", "TABLE", "COL", "COL", false);
+
+        assertThat(matches).as("catalog mismatch alone must not fail the match.").isTrue();
+    }
+
+    private static Stream<Arguments> provideMismatchedCatalogs()
+    {
+        return Stream.of(Arguments.of("CAT_A", "CAT_B"), Arguments.of("CAT_A", null),
+                Arguments.of(null, "CAT_B"), Arguments.of("CAT_A", ""));
+    }
+}

--- a/src/test/java/org/dbunit/ext/mysql/MySqlMetadataHandlerTest.java
+++ b/src/test/java/org/dbunit/ext/mysql/MySqlMetadataHandlerTest.java
@@ -1,0 +1,105 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit.ext.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for {@link MySqlMetadataHandler}, focused on the catalog/schema swap in
+ * {@link MySqlMetadataHandler#matches(ResultSet, String, String, String, String, boolean)} and
+ * its value-based {@link MySqlMetadataHandler#matchesColumn} counterpart: MySQL's
+ * {@code getColumns} rows report only a catalog (MySQL has no schema distinct from its
+ * catalog/database), so a search that expects a schema must be compared against the row's
+ * catalog instead.
+ *
+ * @since 3.2.1
+ */
+class MySqlMetadataHandlerTest
+{
+    private final MySqlMetadataHandler handler = new MySqlMetadataHandler();
+
+    @ParameterizedTest
+    @MethodSource("provideCatalogSchemaTableColumnCombinations")
+    void testMatchesColumn_variousCatalogSchemaTableColumnCombinations_agreesWithResultSetBasedMatches(
+            String searchCatalog, String actualCatalog, String searchSchema, String actualSchema,
+            String searchTable, String actualTable, String searchColumn, String actualColumn,
+            boolean caseSensitive) throws SQLException
+    {
+        final ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString(1)).thenReturn(actualCatalog);
+        when(resultSet.getString(2)).thenReturn(actualSchema);
+        when(resultSet.getString(3)).thenReturn(actualTable);
+        when(resultSet.getString(4)).thenReturn(actualColumn);
+
+        final boolean viaResultSet = handler.matches(resultSet, searchCatalog, searchSchema,
+                searchTable, searchColumn, caseSensitive);
+        final boolean viaValues = handler.matchesColumn(searchCatalog, actualCatalog, searchSchema,
+                actualSchema, searchTable, actualTable, searchColumn, actualColumn, caseSensitive);
+
+        assertThat(viaValues)
+                .as("matchesColumn(...) must agree with matches(ResultSet, ...) for this combination.")
+                .isEqualTo(viaResultSet);
+    }
+
+    private static Stream<Arguments> provideCatalogSchemaTableColumnCombinations()
+    {
+        return Stream.of(
+                // Typical MySQL row shape: only a catalog is reported, no schema.
+                Arguments.of(null, "mydb", "mydb", null, "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of(null, "otherdb", "mydb", null, "TABLE", "TABLE", "COL", "COL", false),
+                // Both catalog and schema supplied on both sides: no swap, plain comparison.
+                Arguments.of("mydb", "mydb", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of("mydb", "otherdb", "SCHEMA", "SCHEMA", "TABLE", "TABLE", "COL", "COL", false),
+                // Neither side supplies a schema: swap condition not met (searchSchema is null).
+                Arguments.of(null, "mydb", null, null, "TABLE", "TABLE", "COL", "COL", false),
+                Arguments.of(null, "mydb", "mydb", null, "TABLE", "WRONG_TABLE", "COL", "COL", false),
+                Arguments.of(null, "mydb", "mydb", null, "TABLE", "TABLE", "COL", "WRONG_COL", false),
+                Arguments.of(null, "mydb", "mydb", null, "table", "TABLE", "col", "COL", false),
+                Arguments.of(null, "mydb", "mydb", null, "table", "TABLE", "col", "COL", true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSwapScenarios")
+    void testMatchesColumn_withOnlyCatalogReportedByRow_comparesRowCatalogAgainstSearchedSchema(
+            String searchSchema, String actualCatalog, boolean expectedMatch)
+    {
+        final boolean matches = handler.matchesColumn(null, actualCatalog, searchSchema, null,
+                "TABLE", "TABLE", "COL", "COL", false);
+
+        assertThat(matches).as("row catalog vs. searched schema comparison after the swap.")
+                .isEqualTo(expectedMatch);
+    }
+
+    private static Stream<Arguments> provideSwapScenarios()
+    {
+        return Stream.of(Arguments.of("mydb", "mydb", true), Arguments.of("mydb", "otherdb", false));
+    }
+}


### PR DESCRIPTION
## Summary

* `ResultSetTableMetaData`'s per-table column-metadata cache (added in #789 / WI-11) was gated to `DefaultMetadataHandler` only, so `MySqlMetadataHandler` and `Db2MetadataHandler` never got the benefit - multi-column tables on MySQL and DB2 still issue one `getColumns()` call per column.
* They were excluded because the cache hardcoded `DefaultMetadataHandler`'s catalog/table matching rules, and both handlers override `matches(ResultSet, ...)` with different semantics (DB2 tolerates catalog mismatches; MySQL swaps its row's catalog into the schema slot).
* Added `IMetadataHandler.matchesColumn(...)` (a value-based counterpart to `matches(ResultSet, ...)`) plus `supportsColumnCache()` (default `false`). `Db2MetadataHandler` and `MySqlMetadataHandler` override both, replicating their existing quirks against plain values instead of a live result set row. The cache gate and per-candidate comparison in `ResultSetTableMetaData` now delegate to these polymorphically instead of hardcoding `DefaultMetadataHandler`'s rules.
* A custom `IMetadataHandler` that doesn't opt in keeps the legacy per-column path via the interface's conservative default - existing custom-handler behavior is unchanged.

**Base branch note**: this targets `jj-performance-improvements` (#789), not `main`, since the cache mechanism being extended doesn't exist on `main` yet. This PR should merge after (or into) that one.

Fixes #792.

## Test plan

* [x] New unit tests: `Db2MetadataHandlerTest` (13 tests) and `MySqlMetadataHandlerTest` (11 tests) - both include a parameterized check that `matchesColumn(...)` agrees with `matches(ResultSet, ...)` across catalog/schema/table/column combinations, including each handler's specific quirk.
* [x] New `ResultSetTableMetaDataTest` test proving the cache now engages for `Db2MetadataHandler` (single `getColumns` call for a 3-column table) - confirmed it fails (3 calls) against the pre-fix gate.
* [x] Full unit suite: 1723 tests, 0 failures.
* [x] Real-database verification (not just mocks): `./mvnw clean verify -Pmysql-9-20` - 314 IT, 0 failures. `./mvnw clean verify -Pdb2-11-5` - 314 IT, 0 failures. Both via Docker containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved column metadata lookup efficiency for MySQL and DB2 databases through expanded caching support.
  * Preserved database-specific matching behavior, including catalog and schema handling.

* **Bug Fixes**
  * Improved consistency when resolving cached column metadata across different database configurations.

* **Tests**
  * Added coverage for MySQL and DB2 metadata matching and cached column resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->