### PR TITLE
Docs/dataset values page

### DIFF
--- a/src/main/java/org/dbunit/util/RelativeDateTimeParser.java
+++ b/src/main/java/org/dbunit/util/RelativeDateTimeParser.java
@@ -115,8 +115,8 @@ public class RelativeDateTimeParser
         {
             throw new IllegalArgumentException("'" + input
                     + "' does not match the expected pattern [now{diff}{time}]. "
-                    + "Please see the data types documentation for the details. "
-                    + "http://dbunit.sourceforge.net/datatypes.html#relativedatetime");
+                    + "Please see the dataset values documentation for the details. "
+                    + "https://dbunit.github.io/dbunit-extension/datasets/values.html#datetime");
         }
 
         LocalDateTime datetime = initLocalDateTime(matcher);

--- a/src/site/asciidoc/datasets.adoc
+++ b/src/site/asciidoc/datasets.adoc
@@ -61,7 +61,8 @@ IDataSet dataSet = new DataSetBuilder()
 
 Each of the following is a focused page — file-based formats first, then the
 programmatic/live sources, then the decorators that wrap any `IDataSet`/
-`ITable` to add behavior:
+`ITable` to add behavior, and finally the cross-cutting rules for how a
+field's text becomes a typed value:
 
 [cols="1,3", options="header"]
 |===
@@ -78,6 +79,7 @@ programmatic/live sources, then the decorators that wrap any `IDataSet`/
 |link:datasets/streaming.html[Streaming Datasets] |`StreamingDataSet` — forward-only, low-memory access over a producer.
 |link:datasets/fileloader.html[Data File Loader] |`DataFileLoader` implementations — load a dataset file from the classpath, with `ReplacementDataSet` substitution built in.
 |link:datasets/decorators.html[Decorators] |`CompositeDataSet`, `FilteredDataSet`, `SortedTable`/`SortedDataSet`, `ReplacementDataSet`, `TableDecoratorDataSet`, `CachedDataSet`.
+|link:datasets/values.html[Dataset Values] |Not a format — how a field's text becomes a typed column value in any of the above: nulls, empty strings, `[TEXT\|BASE64\|FILE\|URL]` and `[now...]` syntax, UUID literals, booleans/numbers from strings, and Flat XML column sensing.
 |===
 
 For a live database as a dataset source (`IDatabaseConnection.createDataSet()`),

--- a/src/site/asciidoc/datasets/csv.adoc
+++ b/src/site/asciidoc/datasets/csv.adoc
@@ -14,6 +14,11 @@ one CSV file per table.
   number.
 * Specify null values as `null` without quotes.
 
+link:values.html[Dataset Values] covers the format-independent rules for
+converting a parsed field value to its column type — empty strings, binary/BLOB
+syntax, literal and relative dates, UUID literals, and booleans and numbers
+from strings. How a null is written is format-specific (see the bullet above).
+
 Sample directory layout for two tables, `TEST_TABLE` and `SECOND_TABLE`:
 
 ----

--- a/src/site/asciidoc/datasets/decorators.adoc
+++ b/src/site/asciidoc/datasets/decorators.adoc
@@ -88,6 +88,11 @@ This provides a declarative way to specify null values in flat XML
 datasets. For example, use a placeholder value like `[NULL]` in the
 flat XML dataset and replace it with `null` at runtime.
 
+link:values.html#null[Dataset Values] frames the `[NULL]` convention against
+each format's built-in null representation, and
+link:values.html#tokens[its token-replacement section] covers using this
+decorator for arbitrary substitutions.
+
 [source,xml]
 ----
 <?xml version="1.0"?>

--- a/src/site/asciidoc/datasets/excel.adoc
+++ b/src/site/asciidoc/datasets/excel.adoc
@@ -10,6 +10,13 @@ contain the data.
 IDataSet dataSet = new XlsDataSet(new File("dataset.xls"));
 ----
 
+An empty or absent cell is read as a null value. Because every column is
+declared in the header row, a later row with a blank cell keeps the column —
+Excel has no "extra columns" problem. For how a cell value becomes a typed
+column value — binary/BLOB syntax, literal and relative dates, UUID literals,
+and booleans/numbers from strings (in text cells) — see
+link:values.html[Dataset Values].
+
 == Dependency
 
 dbUnit depends on https://poi.apache.org/[Apache POI] to read/write Excel

--- a/src/site/asciidoc/datasets/fileloader.adoc
+++ b/src/site/asciidoc/datasets/fileloader.adoc
@@ -80,7 +80,8 @@ IDataSet ds = loader.load("/the/package/prepData.xml");
 
 Every loader's constructors accept replacement object and replacement
 substring maps, used the same way as with `ReplacementDataSet` directly (see
-link:decorators.html#replacementdataset[Decorators]):
+link:decorators.html#replacementdataset[Decorators], and
+link:values.html#null[Dataset Values] for the `[NULL]` convention):
 
 [source,java]
 ----

--- a/src/site/asciidoc/datasets/flatxml.adoc
+++ b/src/site/asciidoc/datasets/flatxml.adoc
@@ -19,17 +19,24 @@ Flat XML dataset document sample:
 </dataset>
 ----
 
-To specify null values, omit corresponding attribute.
-In the above example, missing COL0 and COL2 attributes of TEST_TABLE second row represents null values.
+To specify null values, omit the corresponding attribute.
+In the above example, the missing COL0 and COL2 attributes of TEST_TABLE's second row represent null values.
 
-Table metadata is deduced from the first row of each table by default, whereas it is possible to enable the _column sensing_ feature as described in link:../faq.html#differentcolumnnumber[differentcolumnnumber].
+Table metadata is deduced from the *first* row of each table. On a later row,
+an attribute the first row lacked is ignored — the row is still read, just
+without that column, with an "Extra columns on line x" warning — unless you
+enable _column sensing_ or supply a DTD. See
+link:values.html#columnsensing[Dataset Values: column sensing] for the fix.
 *Beware you may get a NoSuchColumnException if the first row of a table has one or more null values.*
-Because of that, this is highly recommended to use DTD.
-DbUnit will use the columns declared in the DTD as table metadata.
-DbUnit only support external system URI.
-The URI can be absolute or relative.
+Because of that, using a DTD is recommended: DbUnit then takes each table's metadata from the columns declared in the DTD.
+DbUnit supports only an external system URI for the DTD; it can be absolute or relative.
 
-Another way to cope with this problem is to use the link:decorators.html#replacementdataset[ReplacementDataSet].
+link:values.html#null[ReplacementDataSet's `[NULL]` placeholder] is another
+way to cope with a first-row null.
+
+For binary/BLOB data, literal and relative dates, UUID literals, booleans and
+numbers from strings, and empty-string handling, see
+link:values.html[Dataset Values] — those rules are the same for every format.
 
 Build one with link:/dbunit/apidocs/org/dbunit/dataset/xml/FlatXmlDataSetBuilder.html[FlatXmlDataSetBuilder]:
 

--- a/src/site/asciidoc/datasets/json.adoc
+++ b/src/site/asciidoc/datasets/json.adoc
@@ -37,6 +37,10 @@ reading it back produces a table with no columns instead. Formats that
 declare columns independently of row content, such as CSV's per-table header
 row, do not have this limitation.
 
+For what happens to a field value after parsing — empty strings, binary/BLOB
+syntax, literal and relative dates, UUID literals, and booleans/numbers from
+strings — see link:values.html[Dataset Values], which applies to every format.
+
 Table names are always case-sensitive — unlike some other formats, there is no
 case-insensitive table lookup fallback.
 

--- a/src/site/asciidoc/datasets/values.adoc
+++ b/src/site/asciidoc/datasets/values.adoc
@@ -1,0 +1,362 @@
+= Dataset Values
+
+== Overview
+
+Dataset formats store field values as text — always for
+link:flatxml.html[Flat XML], link:xml.html[XML], link:csv.html[CSV],
+link:json.html[JSON], and link:yaml.html[YAML]; for link:excel.html[Excel],
+except where an `.xls` cell is natively a number, date, or boolean. dbUnit
+turns each value into a typed column value with the column's
+link:../datatypes.html[DataType]: `DataType.typeCast()` parses a string using
+the SQL type dbUnit resolved for the column (from database metadata, a DTD, or
+an explicit column declaration), and passes a value that is already the right
+type straight through. Because the conversion is driven by the column's type
+rather than the file format, the rules on this page apply the same way
+whichever format the value came from.
+
+A handful of those rules are triggered by an *extended syntax*: when a string
+value starts with `[`, the binary and date/time types treat the bracketed
+prefix as an instruction rather than literal content
+(`DataType.isExtendedSyntax()` — value starts with `[`). This is how
+`[TEXT|BASE64|FILE|URL]` loads binary data and how `[now...]` produces a
+relative date. String columns never do this — a leading `[` is stored
+verbatim.
+
+The link:decorators.html#replacementdataset[ReplacementDataSet] decorator is a
+separate mechanism: it swaps placeholder objects and substrings *before*
+`typeCast()` sees them, and is the basis for the widely used `[NULL]`
+convention below.
+
+[#null]
+== Null
+
+Each format has its own way to say "this cell is null":
+
+[cols="1,3", options="header"]
+|===
+|Format |Null representation
+
+|link:flatxml.html[Flat XML] |Omit the attribute. A row that does not mention `COL2` has a null `COL2`.
+|link:xml.html[XML] |An explicit `<null/>` or `<none/>` element in the row.
+|link:csv.html[CSV] |The literal token `null`, unquoted. A quoted `"null"` is the four-character string.
+|link:json.html[JSON] |Omit the key from that row's object. (Writing a dataset omits null-valued keys rather than emitting JSON `null`.)
+|link:yaml.html[YAML] |Omit the key from that row's mapping.
+|link:excel.html[Excel] |An empty or absent cell.
+|===
+
+Each format page states its own convention in its own words; the table above
+is a cross-reference, not a replacement.
+
+=== The `[NULL]` placeholder
+
+`[NULL]` is *not* built into the type layer — on a binary column it is
+mangled, on a numeric column it throws, on a string column it is stored
+literally as the five characters `[NULL]`. It only means "null" when a
+link:decorators.html#replacementdataset[ReplacementDataSet] is configured to
+replace it:
+
+[source,java]
+----
+ReplacementDataSet dataSet = new ReplacementDataSet(new FlatXmlDataSet(...));
+dataSet.addReplacementObject("[NULL]", null);
+----
+
+This is the standard way to express null in Flat XML when the first row of a
+table would otherwise carry a null (which, without a DTD, would drop the
+column from the table's metadata). Add `dataSet.setStrictReplacement(true)` to
+fail fast if a placeholder is left unreplaced instead of passing it through
+silently. See link:decorators.html#replacementdataset[ReplacementDataSet] for
+the full mechanics and link:fileloader.html[Data File Loader] for loaders that
+apply replacements automatically.
+
+[#empty]
+== Empty string vs. missing
+
+A missing value is null (previous section). An explicitly empty string —
+`COL=""` in Flat XML — is different: by default dbUnit rejects it on
+`INSERT`/`UPDATE` rather than treating it as null or as an empty string.
+
+----
+table.column=TEST_TABLE.COL0 value is empty but must contain a value (to disable this feature check, set DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS to true)
+----
+
+The check (`AbstractBatchOperation`) fires only for a genuinely empty string
+(`""`), not for null or a missing attribute. Set the
+link:../properties.html#allowemptyfields[`FEATURE_ALLOW_EMPTY_FIELDS`] feature
+to `true` to let empty strings through to the database:
+
+[source,java]
+----
+config.setFeature(DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS, true);
+----
+
+[#binary]
+== Binary, BLOB, and CLOB
+
+dbUnit datasets are text, so binary columns (`BINARY`, `VARBINARY`,
+`LONGVARBINARY`, `BLOB`) use an extended syntax to say how the text should
+become bytes:
+
+----
+... COL0="[TEXT|BASE64|FILE|URL <optional argument>] optional text"
+----
+
+The command word is matched case-insensitively. Everything after the closing
+`]` is the payload.
+
+=== TEXT
+
+Stores the text after `]` as bytes. The default encoding is UTF-8; an optional
+second word overrides it.
+
+[source,xml]
+----
+<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
+<dataset>
+    <TABLE_WITHBLOB COL0="[TEXT]This is my text, saved in UTF-8 (default) encoding.  Java: bon café!"
+                    COL1="row 0 col 1"
+                    COL2="row 0 col 2"/>
+</dataset>
+----
+
+[source,xml]
+----
+<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
+<dataset>
+    <TABLE_WITHBLOB COL0="[TEXT ISO-8859-1]This is my text, saved in ISO-8859-1 encoding.  Java: bon café!"
+                    COL1="row 0 col 1"
+                    COL2="row 0 col 2"/>
+</dataset>
+----
+
+An unknown encoding name is a `TypeCastException`.
+
+=== BASE64
+
+Decodes the Base64 text after `]` into bytes.
+
+[source,xml]
+----
+<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
+<dataset>
+    <TABLE_WITHBLOB COL0="[BASE64]VGhpcyBpcyBteSB0ZXh0Lg=="
+                    COL1="row 0 col 1"
+                    COL2="row 0 col 2"/>
+</dataset>
+----
+
+=== FILE
+
+Reads the bytes from a file. The path is the whole string after `]` and may
+contain spaces.
+
+[source,xml]
+----
+<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
+<dataset>
+    <TABLE_WITHBLOB COL0="[FILE]/path/to file to insert contents"
+                    COL1="row 0 col 1"
+                    COL2="row 0 col 2"/>
+</dataset>
+----
+
+=== URL
+
+Reads the bytes from a URL.
+
+[source,xml]
+----
+<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
+<dataset>
+    <TABLE_WITHBLOB COL0="[URL]http://url%20here"
+                    COL1="row 0 col 1"
+                    COL2="row 0 col 2"/>
+</dataset>
+----
+
+A `FILE` or `URL` that cannot be read is a `TypeCastException` naming the
+instruction.
+
+[#binary-no-prefix]
+=== Without the bracket syntax
+
+A binary value with no `[...]` prefix is resolved by guessing. A value of 1 to
+256 characters is tried as a URL and then as a file path. An empty value, a
+value longer than 256 characters, and any short value that is neither a
+readable URL nor an existing file are Base64-decoded, falling back to raw
+UTF-8 bytes when the text is not valid Base64. A value that is a well-formed
+URL but cannot be fetched is a `TypeCastException` — it does not fall through
+to the file or Base64 step.
+
+An *unrecognized* command such as `[BOGUS]...` is not one of the four above:
+the bracketed prefix is stripped and the remainder is resolved as if it had no
+prefix at all, so the stored value is silently wrong rather than rejected. Use
+only `TEXT`, `BASE64`, `FILE`, or `URL`.
+
+CLOB columns are character data and follow the string rules, not this
+section; `[TEXT|BASE64|FILE|URL]` is for binary types.
+
+[#datetime]
+== Dates and times
+
+=== Literal formats
+
+dbUnit uses the JDBC escape formats:
+
+[cols="1,2", options="header"]
+|===
+|Type |Format
+
+|`DATE` |`yyyy-mm-dd`
+|`TIME` |`hh:mm:ss`
+|`TIMESTAMP` |`yyyy-mm-dd hh:mm:ss.fffffffff`
+|===
+
+A `TIMESTAMP` value may carry a numeric timezone offset suffix such as
+`2024-03-01 12:00:00.0 +0100`; see link:../databases/mssql.html[the MSSQL
+guide] for how `TIMESTAMP WITH TIME ZONE` columns are handled.
+
+=== Relative dates — `[now...]`
+
+Since 2.7.0, a `DATE`, `TIME`, or `TIMESTAMP` field can be written relative to
+the current date/time:
+
+----
+... field_name="[now{diff...}{time}]"
+----
+
+Each `diff` is a signed number followed by a unit character; multiple are
+allowed, in any order, with optional whitespace around each. An optional
+trailing time in `HH:MM` or `HH:MM:SS` form replaces the current time of day —
+the syntax allows only digits and `:`, so no fractional seconds and no zone
+offset. Both the offsets and the time are optional.
+
+* `y` : years
+* `M` : months
+* `d` : days
+* `h` : hours
+* `m` : minutes
+* `s` : seconds
+
+Examples:
+
+* `[now]` — current date/time
+* `[now-1d]` — the same time yesterday
+* `[now+1y+1M-2h]` — a year and a month from today, two hours earlier
+* `[now+1d 10:00]` — 10 o'clock tomorrow
+
+An input that starts with `[` but is not a valid `[now...]` expression is a
+`TypeCastException` — there is no way to store a literal leading `[` in a
+date/time column (see <<literal-bracket,Literal leading bracket>>).
+
+[#uuid]
+== UUIDs in binary columns
+
+A `BINARY`/`VARBINARY`/`LONGVARBINARY` column (mapped by
+link:../datatypes.html#uuidawarebytes[`UuidAwareBytesDataType`]) recognizes a
+UUID literal, so UUIDs stored as raw bytes need not be Base64- or hex-encoded
+by hand. Write the field as
+`uuid'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'` (hex, big-endian); it is stored
+as the 16-byte encoding. The literal is matched anywhere in the value, so
+anything around it is discarded — keep the field to just the literal.
+
+[source,xml]
+----
+<company id="uuid'791ae85a-d8d0-11e2-8c43-50e549c9b654'" name="ACME"/>
+----
+
+This applies to `BINARY`-family columns only. A `BLOB` column
+(`BlobDataType`) does not decode the literal — it would store the 42
+characters of `uuid'...'` as text bytes.
+
+[#boolean]
+== Booleans and numbers from strings
+
+*Boolean columns* (`BOOLEAN`, `BIT`): `true` and `false` are recognized
+case-insensitively. Any other value is parsed as an integer, then `0` is
+`false` and any non-zero is `true`. A value that is neither (`yes`, `y`, ...)
+is a `TypeCastException`.
+
+*Integer columns* (`TINYINT`, `SMALLINT`, `INTEGER`): also accept `true` /
+`false` (case-insensitive) as `1` / `0`, otherwise parse the value as a
+number.
+
+*Decimal columns* (`NUMERIC`, `DECIMAL`): a `Boolean` value becomes `1` or
+`0`, but the *strings* `"true"` / `"false"` are not special here — they are a
+`TypeCastException`. Everything else goes through `new BigDecimal(value)`.
+
+In link:csv.html[CSV], a numeric field with a trailing space before the comma
+is read as a string, not a number.
+
+[#tokens]
+== Token and placeholder replacement
+
+dbUnit has no built-in templating in field values beyond what the sections
+above describe. Arbitrary substitution is done by the
+link:decorators.html#replacementdataset[ReplacementDataSet] /
+`ReplacementTable` decorators, which replace whole placeholder objects and
+substrings that you register:
+
+[source,java]
+----
+ReplacementDataSet dataSet = new ReplacementDataSet(new FlatXmlDataSet(...));
+dataSet.addReplacementObject("[NULL]", null);
+dataSet.addReplacementSubstring("$USER", "scott");
+----
+
+link:../faq.html#systemTimeInTest[Injecting the current system time] is a
+worked example — register a `java.util.Date` object under a placeholder and it
+is substituted before comparison or insert. link:fileloader.html[Data File
+Loader] implementations wrap every dataset they load in a `ReplacementDataSet`
+automatically.
+
+[#literal-bracket]
+== Literal leading bracket
+
+A value that starts with `[` is only special for binary and date/time
+columns:
+
+[cols="1,3", options="header"]
+|===
+|Column type |A value starting with `[`
+
+|String / CLOB |Stored verbatim. `[NULL]`, `[foo]`, `[TEXT]x` are all literal text.
+|`DATE` / `TIME` / `TIMESTAMP` |Always parsed as a `[now...]` expression; anything else is a `TypeCastException`. No escape.
+|Binary / BLOB |Always parsed as `[TEXT\|BASE64\|FILE\|URL]`; an unrecognized command is dropped silently (see <<binary-no-prefix,Without the bracket syntax>>). No escape.
+|===
+
+There is no escape character for a leading `[` on a binary or temporal column.
+If a date/time or binary column must hold a value that would collide with the
+extended syntax, substitute it in with a
+link:decorators.html#replacementdataset[ReplacementDataSet] instead of writing
+it in the file.
+
+[#columnsensing]
+== Column sensing (Flat XML)
+
+link:flatxml.html[Flat XML] deduces a table's columns from its *first* row. A
+later row with an attribute the first row lacked produces:
+
+----
+Extra columns on line x. Those columns will be ignored. Please add the extra
+columns to line 1, or use a DTD to make sure the value of those columns are populated.
+----
+
+Three ways to fix it:
+
+* Declare every column on the first row (use `[NULL]` or omit-for-null as
+  needed).
+* Reference a DTD — dbUnit takes the table's columns from it.
+* Enable column sensing, which buffers the whole document and adds columns as
+  they first appear:
+
+[source,java]
+----
+FlatXmlDataSetBuilder builder = new FlatXmlDataSetBuilder();
+builder.setColumnSensing(true);
+IDataSet dataSet = builder.build(new File("dataset.xml"));
+----
+
+link:yaml.html[YAML] and link:json.html[JSON] do not have this problem — they
+take a table's columns from the union of all its rows. link:csv.html[CSV]
+declares columns in a header row, so it is unaffected too.

--- a/src/site/asciidoc/datasets/xml.adoc
+++ b/src/site/asciidoc/datasets/xml.adoc
@@ -83,3 +83,8 @@ it directly from the GitHub repository instead:
 Compared to link:flatxml.html[Flat XML], this format is self-describing (the
 columns are explicit per table, rather than deduced from attributes) at the
 cost of considerably more verbose files.
+
+A null value is written as an explicit `<null/>` or `<none/>` element in the
+row. For how field text becomes a typed value once parsed — empty strings,
+binary/BLOB syntax, literal and relative dates, UUID literals, and
+booleans/numbers from strings — see link:values.html[Dataset Values].

--- a/src/site/asciidoc/datasets/yaml.adoc
+++ b/src/site/asciidoc/datasets/yaml.adoc
@@ -26,3 +26,7 @@ In the above example, missing COL0 and COL2 keys of TEST_TABLE second row repres
 In contrast to link:flatxml.html[Flat XML], table metadata is deduced from
 the sum of all rows for each table, not just the first — so a column that
 first appears on a later row is still picked up.
+
+For what happens to a field value after parsing — empty strings, binary/BLOB
+syntax, literal and relative dates, UUID literals, and booleans/numbers from
+strings — see link:values.html[Dataset Values], which applies to every format.

--- a/src/site/asciidoc/datatypes.adoc
+++ b/src/site/asciidoc/datatypes.adoc
@@ -13,6 +13,11 @@ link:databases.html[Database-Specific Guides] for vendor-specific types
 (Oracle `SDO_GEOMETRY`, PostgreSQL `citext`/`interval`/`inet`, MSSQL
 `uniqueidentifier`/`datetimeoffset`, and more) not covered here.
 
+How a dataset field's text becomes a typed value of one of these types —
+nulls, empty strings, the `[TEXT|BASE64|FILE|URL]` and `[now...]` bracket
+syntaxes, UUID literals, booleans and numbers from strings — is covered in
+link:datasets/values.html[Dataset Values].
+
 [cols="2,2,5", options="header"]
 |===
 |Type |Java Type |Notes
@@ -20,11 +25,11 @@ link:databases.html[Database-Specific Guides] for vendor-specific types
 |`BigIntegerDataType` |`java.math.BigInteger` |The default mapping for SQL `BIGINT`.
 |`BinaryStreamDataType` |`byte[]` |Reads via `ResultSet.getBinaryStream()` instead of `getBytes()`. Not registered by default — used by vendor factories for large binary values, e.g. Oracle's `LONG RAW` and streamed `BLOB` (`OracleDataTypeFactory`/`Oracle10DataTypeFactory`).
 |`BitDataType` |`Boolean` |The default mapping for SQL `BIT`; extends `BooleanDataType`.
-|`BlobDataType` |`byte[]` |The default mapping for SQL `BLOB`. See <<blob,Blob>> below for the `[TEXT\|BASE64\|FILE\|URL]` load syntax.
+|`BlobDataType` |`byte[]` |The default mapping for SQL `BLOB`. See link:datasets/values.html#binary[Dataset Values] for the `[TEXT\|BASE64\|FILE\|URL]` load syntax.
 |`BooleanDataType` |`Boolean` |The default mapping for SQL `BOOLEAN`.
 |`BytesDataType` |`byte[]` |Abstract base for the binary types above/below; not itself registered for any SQL type.
 |`ClobDataType` |`String` |The default mapping for SQL `CLOB`; extends `StringDataType`.
-|`DateDataType` |`java.sql.Date` |The default mapping for SQL `DATE`. See <<relativedatetime,Relative Date, Time, and Timestamp>> below.
+|`DateDataType` |`java.sql.Date` |The default mapping for SQL `DATE`. See link:datasets/values.html#datetime[Dataset Values] for literal and relative (`[now...]`) date syntax.
 |`DoubleDataType` |`Double` |The default mapping for SQL `DOUBLE` *and* SQL `FLOAT` — see the naming note under `FloatDataType`.
 |`FloatDataType` |`Float` |The default mapping for SQL `REAL`. Confusingly, SQL `FLOAT` maps to `DoubleDataType`/Java `Double` while SQL `REAL` maps here, to Java `Float` — this mirrors `java.sql.Types`, not a dbUnit choice.
 |`IntegerDataType` |`Integer` |The default mapping for SQL `TINYINT`, `SMALLINT`, and `INTEGER`.
@@ -33,101 +38,10 @@ link:databases.html[Database-Specific Guides] for vendor-specific types
 |`NumberTolerantDataType` |`java.math.BigDecimal` |A `NumberDataType` variant comparing within a tolerance instead of requiring an exact match. See <<numbertolerant,NumberTolerantDataType>> below.
 |`StringDataType` |`String` |The default mapping for SQL `CHAR`, `VARCHAR`, `LONGVARCHAR`, `NCHAR`, `NVARCHAR`, and `LONGNVARCHAR`.
 |`StringIgnoreCaseDataType` |`String` |A `StringDataType` variant comparing case-insensitively. See <<stringignorecase,StringIgnoreCaseDataType>> below.
-|`TimeDataType` |`java.sql.Time` |The default mapping for SQL `TIME`. See <<relativedatetime,Relative Date, Time, and Timestamp>> below.
-|`TimestampDataType` |`java.sql.Timestamp` |The default mapping for SQL `TIMESTAMP`. See <<relativedatetime,Relative Date, Time, and Timestamp>> below.
-|`UuidAwareBytesDataType` |`byte[]` |The default mapping for SQL `BINARY`/`VARBINARY`/`LONGVARBINARY` — a `BytesDataType` variant additionally recognizing a UUID literal. See <<uuidawarebytes,UuidAwareBytesDataType>> below.
+|`TimeDataType` |`java.sql.Time` |The default mapping for SQL `TIME`. See link:datasets/values.html#datetime[Dataset Values] for literal and relative (`[now...]`) time syntax.
+|`TimestampDataType` |`java.sql.Timestamp` |The default mapping for SQL `TIMESTAMP`. See link:datasets/values.html#datetime[Dataset Values] for literal and relative (`[now...]`) timestamp syntax.
+|`UuidAwareBytesDataType` |`byte[]` |The default mapping for SQL `BINARY`/`VARBINARY`/`LONGVARBINARY` — a `BytesDataType` variant additionally recognizing a UUID literal. See <<uuidawarebytes,UuidAwareBytesDataType>> below and link:datasets/values.html#uuid[Dataset Values] for the syntax.
 |===
-
-[#blob]
-== Blob
-
-link:apidocs/org/dbunit/dataset/datatype/BlobDataType.html[Blob JavaDoc]
-
-Blobs contain binary data.
-DbUnit, however, processes data with XML or CSV files containing textual data sets, not binary.
-To push binary data into a database blob from dbUnit data set files, use the following syntax in a data set field:
-
-----
-... field_name="[TEXT|BASE64|FILE|URL <optional argument>] optional text"
-----
-
-The following sections show how to use each of the forms available to load binary data into a blob.
-
-=== TEXT
-
-Insert text in a blob. By default the encoding used is UTF-8, but optionally any encoding can be provided.
-
-Example with UTF-8 encoding:
-
-[source,xml]
-----
-<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
-<dataset>
-    <TABLE_WITHBLOB COL0="[TEXT]This is my text, saved in UTF-8 (default) encoding.  Java: bon café!"
-                    COL1="row 0 col 1"
-                    COL2="row 0 col 2"/>
-</dataset>
-----
-
-Example with ISO-8859-1 encoding:
-
-[source,xml]
-----
-<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
-<dataset>
-    <TABLE_WITHBLOB COL0="[TEXT ISO-8859-1]This is my text, saved in ISO-8859-1 encoding.  Java: bon café!"
-                    COL1="row 0 col 1"
-                    COL2="row 0 col 2"/>
-</dataset>
-----
-
-=== BASE64
-
-Insert binary in a blob using Base64.
-
-Example:
-
-[source,xml]
-----
-<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
-<dataset>
-    <TABLE_WITHBLOB COL0="[BASE64]VGhpcyBpcyBteSB0ZXh0Lg=="
-                    COL1="row 0 col 1"
-                    COL2="row 0 col 2"/>
-</dataset>
-----
-
-=== FILE
-
-Insert the content of a binary file in a blob. The path may contains spaces.
-
-Example:
-
-[source,xml]
-----
-<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
-<dataset>
-    <TABLE_WITHBLOB COL0="[FILE]/path/to file to insert contents"
-                    COL1="row 0 col 1"
-                    COL2="row 0 col 2"/>
-</dataset>
-----
-
-=== URL
-
-Insert the content pointed by a URL in a blob.
-
-Example:
-
-[source,xml]
-----
-<!DOCTYPE dataset SYSTEM "my-dataset.dtd">
-<dataset>
-    <TABLE_WITHBLOB COL0="[URL]http://url%20here"
-                    COL1="row 0 col 1"
-                    COL2="row 0 col 2"/>
-</dataset>
-----
 
 [#numbertolerant]
 == NumberTolerantDataType
@@ -173,46 +87,8 @@ link:properties.html#typefactory[the DataType Factory property].
 
 link:apidocs/org/dbunit/dataset/datatype/UuidAwareBytesDataType.html[UuidAwareBytesDataType JavaDoc]
 
-The default `DataType` for SQL `BINARY`/`VARBINARY`/`LONGVARBINARY` columns.
-It behaves like `BytesDataType`, plus recognizes a UUID literal so you don't
-have to base64- or hex-encode UUIDs stored in binary columns by hand. For the
-literal to be detected, the field value must be in the form
-`uuid'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'` (hex-encoded, big-endian):
-
-[source,xml]
-----
-<company id="uuid'791ae85a-d8d0-11e2-8c43-50e549c9b654'" name="ACME"/>
-----
-
-[#relativedatetime]
-== Relative date, time, and timestamp
-
-It is possible to push date, time, and timestamp values relative to the current date/time by using the following syntax in a data set field (since 2.7.0):
-
-----
-... field_name="[now{diff...}{time}]"
-----
-
-`diff` consists of two parts 1) a number with a leading plus or minus sign and 2) a character represents temporal unit.
-See the list below for the supported units.
-There can be multiple `diff`s and they can be specified in any order.
-
-`time` is a string that can be parsed by `LocalTime#parse()`.
-If specified, it is used instead of the current time.
-
-Both `diff` and `time` are optional.
-Whitespaces are allowed before and after each `diff`.
-
-* y : years
-* M : months
-* d : days
-* h : hours
-* m : minutes
-* s : seconds
-
-Here are some examples:
-
-* `[now]` : current date time
-* `[now-1d]` : the same time yesterday
-* `[now+1y+1M-2h]` : a year and a month from today, two hours earlier
-* `[now+1d 10:00]` : 10 o'clock tomorrow
+The default `DataType` for SQL `BINARY`/`VARBINARY`/`LONGVARBINARY` columns. It
+behaves like `BytesDataType`, plus recognizes a UUID literal so UUIDs stored
+in binary columns need not be base64- or hex-encoded by hand. The
+`uuid'...'` field syntax is documented in
+link:datasets/values.html#uuid[Dataset Values].

--- a/src/site/asciidoc/properties.adoc
+++ b/src/site/asciidoc/properties.adoc
@@ -69,7 +69,7 @@ _Note:_ this feature was not compatible with the <<escapepattern,escape pattern>
 |anchor:allowemptyfields[]`FEATURE_ALLOW_EMPTY_FIELDS`
 |http://www.dbunit.org/features/allowEmptyFields
 |false
-|Allow to call INSERT/UPDATE with empty strings ('').
+|Allow `INSERT`/`UPDATE` with empty-string field values instead of rejecting them. See link:datasets/values.html#empty[Dataset Values: empty string vs. missing].
 
 |anchor:sortallcolumnswhennoprimarykey[]`FEATURE_SORT_ALL_COLUMNS_WHEN_NO_PRIMARY_KEY`
 |http://www.dbunit.org/features/sortAllColumnsWhenNoPrimaryKey

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -185,9 +185,10 @@ public class DatabaseExportSample
      How to specify NULL values with flat XML dataset?
       </question>
       <answer>
-      <p>See <a href="datasets/flatxml.html">FlatXmlDataSet documentation</a></p>
+      <p>Omit the attribute, or use the <code>[NULL]</code> placeholder with a ReplacementDataSet.
+      See <a href="datasets/values.html#null">Dataset Values: Null</a>.</p>
       </answer>
-    </faq>  
+    </faq>
     
     <faq id="views">
       <question>
@@ -221,32 +222,12 @@ public class DatabaseExportSample
       What are the date formats supported by DbUnit?
       </question>
       <answer>
-     <p>DbUnit use the JDBC escape formats for string representation.
-      <table border="1">
-        <tr> 
-          <th>Type</th>
-          <th>Format</th>
-        </tr>
-        <tr> 
-          <td>DATE</td>
-          <td>yyyy-mm-dd</td>
-        </tr>
-        <tr> 
-          <td>TIME</td>
-          <td>hh:mm:ss</td>
-        </tr>
-        <tr> 
-          <td>TIMESTAMP</td>
-          <td>yyyy-mm-dd hh:mm:ss.fffffffff</td>
-        </tr>
-      </table>
-</p>
-      <p>
-      There also is special syntax to set relative date, time and timestamp.
-      See <a href="datatypes.html#relativedatetime">data types documentation</a>.
-      </p>
+      <p>DbUnit uses the JDBC escape formats (<code>yyyy-mm-dd</code>, <code>hh:mm:ss</code>,
+      <code>yyyy-mm-dd hh:mm:ss.fffffffff</code>), plus a <code>[now...]</code> syntax for
+      relative dates, times, and timestamps.
+      See <a href="datasets/values.html#datetime">Dataset Values: Dates and times</a>.</p>
       </answer>
-    </faq>    
+    </faq>
 
     <faq id="typefactory">
       <question>
@@ -595,33 +576,15 @@ connection.getConfig().setProperty(
     
     <faq id="differentcolumnnumber">
       <question>
-      I'm getting the following message: Extra columns on line x.  Those columns will be ignored.  
+      I'm getting the following message: Extra columns on line x.  Those columns will be ignored.
       Please add the extra columns to line 1, or use a DTD to make sure the value of those columns are populated.
       Why is that?
       </question>
       <answer>
         <p>
-        DbUnit uses the first tag for a table to define the columns to be populated.  If the following records 
-        for this table contain extra columns, these ones will therefore not be populated.  To solve this, either
-        define all the columns of the table in the first row (using NULL values for the empty columns), or use
-        a DTD to define the metadata of the tables you use.
-        </p>
-        <p>
-        Since DBUnit 2.3.0 there is a functionality called "column sensing" which basically reads in the whole XML into
-        a buffer and dynamically adds new columns as they appear. It can be used as demonstrated in the following example:
-          <source>
-//Since release 2.4.7 we use a builder:
-FlatXmlDataSetBuilder builder = new FlatXmlDataSetBuilder();
-builder.setColumnSensing(true);
-IDataSet dataSet = builder.build(new File("src/xml/flatXmlTableTest.xml"));
-          </source>
-          <source>
-              //This is for release &lt; 2.4.7
-              <del>
-boolean enableColumnSensing = true;
-IDataSet dataSet = new FlatXmlDataSet(new File("src/xml/flatXmlTableTest.xml"), false, enableColumnSensing);
-              </del>
-          </source>
+        Flat XML takes each table's columns from its first row, so an attribute that first appears
+        on a later row is dropped. Declare every column on the first row, supply a DTD, or enable
+        column sensing. See <a href="datasets/values.html#columnsensing">Dataset Values: Column sensing</a>.
         </p>
       </answer>
     </faq>
@@ -786,14 +749,9 @@ PostgresqlDataTypeFactory factory = new PostgresqlDataTypeFactory(){
      I am using UUIDs mapped to a binary column in the database, but encoding them in base64 for datasets is a bit awkward. Is there another way to use them in DbUnit datasets while being able to see the UUIDs clearly?
       </question>
       <answer>
-      <p>Use the special UUID syntax (uuid'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', where all the x's are the hex-encoded string value of your UUID):
-        <source>
-          <![CDATA[
-            <my_table uuid="uuid'029afe42-d8e7-11e2-aca1-50e549c9b654'" another_column="another column value"/>
-          ]]>
-        </source>
-      </p>
-      <p>See <a href="datatypes.html#uuidawarebytes">UuidAwareBytesDataType</a> for details.</p>
+      <p>Yes &#8212; write <code>uuid'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'</code> (the hex UUID) in the
+      field of a BINARY/VARBINARY column. See
+      <a href="datasets/values.html#uuid">Dataset Values: UUIDs in binary columns</a>.</p>
       </answer>
     </faq>
   </part>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -85,8 +85,9 @@
         <item name="SQL*Loader"         href="/datasets/sqlloader.html"/>
         <item name="Query-Based"        href="/datasets/query.html"/>
         <item name="Streaming Datasets" href="/datasets/streaming.html"/>
-        <item name="Data File Loader"   href="/datasets/fileloader.html"/>
         <item name="Decorators"         href="/datasets/decorators.html"/>
+        <item name="Dataset Values"     href="/datasets/values.html"/>
+        <item name="Data File Loader"   href="/datasets/fileloader.html"/>
       </item>
       <item name="Data Comparisons"  href="/datacomparisons.html">
         <item name="Equality"        href="/datacomparisons/equality.html"/>

--- a/src/test/java/org/dbunit/util/RelativeDateTimeParserTest.java
+++ b/src/test/java/org/dbunit/util/RelativeDateTimeParserTest.java
@@ -93,8 +93,8 @@ class RelativeDateTimeParserTest
         {
             assertEquals("'" + input
                     + "' does not match the expected pattern [now{diff}{time}]. "
-                    + "Please see the data types documentation for the details. "
-                    + "http://dbunit.sourceforge.net/datatypes.html#relativedatetime",
+                    + "Please see the dataset values documentation for the details. "
+                    + "https://dbunit.github.io/dbunit-extension/datasets/values.html#datetime",
                     e.getMessage());
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Consolidate dataset value guidance into a dedicated documentation page and update related references throughout the project.

New Features:
- Add comprehensive documentation for dataset values, including supported value formats and data types.

Bug Fixes:
- Update relative date-time parser errors to link to the new dataset values documentation.

Enhancements:
- Reorganize and expand dataset documentation while reducing duplicated data type guidance.
- Add the dataset values page to the site navigation and update related documentation links and FAQ content.

Documentation:
- Document dataset value syntax and behavior in a dedicated user-facing page.
- Refresh dataset format documentation and cross-references to align with the new dataset values guide.

Tests:
- Update relative date-time parser tests to verify the new documentation reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Dataset Values documentation covering nulls, empty strings, binary data, dates, UUIDs, booleans, numbers, token replacement, and column sensing.
  - Added links to the new guidance throughout dataset format, decorator, datatype, property, FAQ, and navigation pages.
  - Clarified format-specific behavior, including XML null handling, Excel cells, and Flat XML extra-column handling.
  - Updated date-time parsing error guidance to reference the current documentation URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->