### PR TITLE
fix(dataset): Reject an unrecognized [command] prefix on binary columns

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -48,6 +48,9 @@
       <action dev="jeffjensen" type="add" issue="973" system="github" due-to="jeffjensen">
           Add RegularExpressionValueComparer to org.dbunit.assertion.comparer.value: a ValueComparer that reads the expected dataset value as a regular expression and passes when it matches the actual value in its entirety (Matcher.matches(), the same whole-value rule as String.matches()), for verifying columns whose format a test controls but whose exact content it does not, such as database-generated ids, UUID columns, or timestamps rendered into a text column. A partial match is opt-in by making the pattern permissive at both ends, and an invalid pattern raises DatabaseUnitException naming the row and column. Also exposed as the ValueComparers.regularExpressionValueComparer constant, since it adds no dependency beyond java.util.regex.
       </action>
+      <action dev="jeffjensen" type="fix" issue="976" system="github" due-to="jeffjensen">
+          Fix BytesDataType silently accepting an unrecognized [command] prefix on a binary column (BINARY, VARBINARY, LONGVARBINARY, BLOB): the [command] was dropped and the remainder stored as whatever it decoded to (URL, file, Base64, or raw UTF-8 bytes), so a value such as [NULL] left unreplaced by a ReplacementDataSet silently became empty bytes instead of failing. An unrecognized command now throws TypeCastException naming it and the four valid commands (TEXT, BASE64, FILE, URL). A value that starts with [ but has no closing ] does not match the command pattern and is unchanged, still treated as literal content.
+      </action>
     </release>
     <release version="3.5.2" date="Sep 7, 2026" description="DefaultPrepAndExpectedTestCase connection hygiene: replace a connection the pool or database dropped between tests, and warn when handed a non-autocommit connection">
       <action dev="jeffjensen" type="fix" issue="962" system="github" due-to="jeffjensen">

--- a/src/main/java/org/dbunit/dataset/datatype/BytesDataType.java
+++ b/src/main/java/org/dbunit/dataset/datatype/BytesDataType.java
@@ -268,6 +268,13 @@ public class BytesDataType extends AbstractDataType
                             logger.error(errMsg);
                             throw new TypeCastException(errMsg, e);
                         }
+                    } else
+                    {
+                        logger.error(
+                                "Unrecognized command <{}> in binary extended-syntax value"
+                                        + " <{}> - expected [TEXT], [BASE64], [FILE] or [URL]",
+                                command, value);
+                        throw new TypeCastException(value, this);
                     }
                 }
             }

--- a/src/site/asciidoc/datasets/values.adoc
+++ b/src/site/asciidoc/datasets/values.adoc
@@ -49,9 +49,9 @@ is a cross-reference, not a replacement.
 
 === The `[NULL]` placeholder
 
-`[NULL]` is *not* built into the type layer — on a binary column it is
-mangled, on a numeric column it throws, on a string column it is stored
-literally as the five characters `[NULL]`. It only means "null" when a
+`[NULL]` is *not* built into the type layer — on a binary or numeric column it
+is a `TypeCastException`, and on a string column it is stored literally as the
+five characters `[NULL]`. It only means "null" when a
 link:decorators.html#replacementdataset[ReplacementDataSet] is configured to
 replace it:
 
@@ -188,10 +188,12 @@ UTF-8 bytes when the text is not valid Base64. A value that is a well-formed
 URL but cannot be fetched is a `TypeCastException` — it does not fall through
 to the file or Base64 step.
 
-An *unrecognized* command such as `[BOGUS]...` is not one of the four above:
-the bracketed prefix is stripped and the remainder is resolved as if it had no
-prefix at all, so the stored value is silently wrong rather than rejected. Use
-only `TEXT`, `BASE64`, `FILE`, or `URL`.
+A value whose `[...]` prefix is not one of the four commands — `[BOGUS]...`, or
+the `[NULL]` placeholder if it reaches a binary column without a
+link:decorators.html#replacementdataset[ReplacementDataSet] — is a
+`TypeCastException` naming the unrecognized command. A value that starts with
+`[` but has no closing `]` is not command syntax and is resolved as a raw
+value, as above.
 
 CLOB columns are character data and follow the string rules, not this
 section; `[TEXT|BASE64|FILE|URL]` is for binary types.
@@ -322,7 +324,7 @@ columns:
 
 |String / CLOB |Stored verbatim. `[NULL]`, `[foo]`, `[TEXT]x` are all literal text.
 |`DATE` / `TIME` / `TIMESTAMP` |Always parsed as a `[now...]` expression; anything else is a `TypeCastException`. No escape.
-|Binary / BLOB |Always parsed as `[TEXT\|BASE64\|FILE\|URL]`; an unrecognized command is dropped silently (see <<binary-no-prefix,Without the bracket syntax>>). No escape.
+|Binary / BLOB |Always parsed as `[TEXT\|BASE64\|FILE\|URL]`; an unrecognized command is a `TypeCastException` (see <<binary-no-prefix,Without the bracket syntax>>). No escape.
 |===
 
 There is no escape character for a leading `[` on a binary or temporal column.

--- a/src/test/java/org/dbunit/dataset/datatype/BytesDataTypeTest.java
+++ b/src/test/java/org/dbunit/dataset/datatype/BytesDataTypeTest.java
@@ -284,6 +284,55 @@ class BytesDataTypeTest extends AbstractDataTypeTest
     }
 
     @Test
+    void testTypeCast_unrecognizedBracketCommand_throwsTypeCastException()
+    {
+        final String value = "[BOGUS]YWJj";
+        final BytesDataType dataType = new BytesDataType("BINARY", Types.BINARY);
+
+        assertThatExceptionOfType(TypeCastException.class)
+                .as("A [command] prefix that is not one of TEXT, BASE64,"
+                        + " FILE, or URL must fail fast instead of silently"
+                        + " dropping the prefix and storing whatever the"
+                        + " remainder decodes to.")
+                .isThrownBy(() -> dataType.typeCast(value))
+                .withMessageContaining(value);
+    }
+
+    @Test
+    void testTypeCast_nullPlaceholderOnBinaryColumn_throwsTypeCastException()
+    {
+        // [NULL] is a ReplacementDataSet convention, not a binary field
+        // command; reaching BytesDataType with it unreplaced is a
+        // configuration error and must not silently become empty bytes.
+        final String value = "[NULL]";
+        final BytesDataType dataType =
+                new BytesDataType("VARBINARY", Types.VARBINARY);
+
+        assertThatExceptionOfType(TypeCastException.class)
+                .isThrownBy(() -> dataType.typeCast(value));
+    }
+
+    @Test
+    void testTypeCast_leadingBracketWithoutClose_isTreatedAsLiteralContent()
+            throws Exception
+    {
+        // A '[' with no closing ']' does not match the command pattern at
+        // all, so it is not command syntax - it stays a raw value and falls
+        // back to its literal UTF-8 bytes, unchanged by the unknown-command
+        // check.
+        final String value = "[not a command";
+        final byte[] expected = value.getBytes(StandardCharsets.UTF_8);
+        final BytesDataType dataType = new BytesDataType("BINARY", Types.BINARY);
+
+        final Object actual = dataType.typeCast(value);
+
+        assertThat(actual)
+                .as("A value starting with '[' but without a closing ']'"
+                        + " must fall back to literal UTF-8 bytes, not throw.")
+                .isEqualTo(expected);
+    }
+
+    @Test
     void testTypeCast_untaggedTextFallback_usesUtf8Bytes() throws Exception
     {
         final String nonAsciiValue = "café!";


### PR DESCRIPTION
Fixes #976.

`BytesDataType.typeCast` recognizes the `[TEXT|BASE64|FILE|URL]` extended syntax on binary columns (`BINARY`, `VARBINARY`, `LONGVARBINARY`, `BLOB`). When the bracketed command was **not** one of those four, the `if / else if` chain fell through with the value already truncated to the part after `]` — the `[command]` prefix silently dropped — and the remainder was stored as whatever it decoded to (URL, file, Base64, or raw UTF-8 bytes).

The most common way this bites: `[NULL]` — a `ReplacementDataSet` convention, not a datatype command — reaching a binary column with no replacement configured. It silently inserted empty bytes instead of failing.

## Change

* An unrecognized `[command]` now throws `TypeCastException` via the existing `TypeCastException(Object value, DataType dataType)` constructor — the same one the recognized commands' fail-fast throws in this method use, so there is no API change. The unrecognized command and the four valid names are logged at ERROR.
* A value that starts with `[` but has **no** closing `]` does not match the command pattern and is unchanged — still resolved as a raw value.
* Updates the Dataset Values page for the new behavior.

## Tests

`BytesDataTypeTest` +3 — unrecognized command throws, `[NULL]` on a binary column throws, `[` without `]` still falls back to literal UTF-8 bytes.

## History

Supersedes #977, which GitHub auto-closed when its stacked base branch (`docs/dataset-values-page`, now merged as part of #975) was deleted. Same commit, rebased onto `main`. Sourcery's earlier finding on #977 (an ambiguous new `TypeCastException(String)` overload) is already addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaCA8dcNX7whN1143ZZwYJ

## Summary by Sourcery

Fail fast when binary values use an unrecognized extended-syntax command while retaining literal handling for incomplete bracketed values.

Bug Fixes:
- Reject unrecognized bracketed commands on binary columns with a TypeCastException instead of silently dropping the prefix and decoding the remaining value.
- Preserve values beginning with an unmatched opening bracket as literal binary content.

Documentation:
- Document the binary-column behavior for unrecognized bracketed commands and unmatched opening brackets.

Tests:
- Add coverage for unrecognized commands, unreplaced [NULL] placeholders, and unmatched opening brackets in binary values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Binary values with unrecognized command prefixes now return a clear `TypeCastException` instead of being silently altered.
  - Unreplaced `[NULL]` placeholders on binary columns now produce an error.
  - Values beginning with `[` but lacking a closing bracket continue to be treated as literal content.

- **Documentation**
  - Updated dataset value documentation to describe the revised binary value handling and supported commands.

- **Tests**
  - Added coverage for invalid commands, unreplaced null placeholders, and literal leading brackets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->