### PR TITLE
Ci/workflow linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint configuration — see .github/workflows/lint-workflows.yml.
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+paths:
+  .github/workflows/release.yml:
+    ignore:
+      # The announcement steps pass `$owner`, `$name`, `$title` inside
+      # single-quoted `gh api graphql` / `jq` programs on purpose — those
+      # tools do the substitution, not the shell. SC2016 is a false positive.
+      - 'shellcheck reported issue in this script: SC2016'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,14 @@ version: 2
 updates:
   # -----------------------------------------------------------------------
   # Maven dependencies — weekly, grouped to reduce changes.xml churn.
+  # A 7-day cooldown lets a bad or compromised release be yanked first.
   # -----------------------------------------------------------------------
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       # Maven build and reporting plugins
@@ -35,12 +38,16 @@ updates:
 
   # -----------------------------------------------------------------------
   # GitHub Actions — daily, all actions grouped into one PR.
-  # (Kept daily so security-relevant action pins are updated quickly.)
+  # Checked daily so security-relevant action pins are picked up quickly;
+  # a short 3-day cooldown still lets an obviously-bad release be pulled.
   # -----------------------------------------------------------------------
+  # zizmor: ignore[dependabot-cooldown]  # 3 days is a deliberate tradeoff for actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       actions-updates:                 # Group all action updates into one PR

--- a/.github/workflows/build-any-branch-with-all-dbs.yml
+++ b/.github/workflows/build-any-branch-with-all-dbs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write  # advanced-security/maven-dependency-submission-action submits the dependency graph
+      contents: read
     steps:
     - uses: actions/checkout@v7
       with:
@@ -35,9 +35,6 @@ jobs:
     - uses: ./.github/actions/jdk-setup
     - name: Compile and run unit tests
       run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} clean test
-    - name: Submit dependencies to GitHub
-      if: github.actor != 'dependabot[bot]'
-      uses: advanced-security/maven-dependency-submission-action@a64327a7329c9939cf675e458452febe1894a70c # v6.0.1
     - name: Upload target directory for reuse
       uses: actions/upload-artifact@v7
       with:
@@ -50,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write  # advanced-security/maven-dependency-submission-action submits the dependency graph
+      contents: read
     strategy:
       matrix:
         database: [
@@ -80,6 +77,3 @@ jobs:
           path: target/
       - name: Run ${{ matrix.database.name }} integration tests
         run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} -P${{ matrix.database.profile }} verify ${{ matrix.database.url != '' && format('-Ddbunit.profile.url={0}', matrix.database.url) || '' }}
-      - name: Submit dependencies to GitHub
-        if: github.actor != 'dependabot[bot]'
-        uses: advanced-security/maven-dependency-submission-action@a64327a7329c9939cf675e458452febe1894a70c # v6.0.1

--- a/.github/workflows/build-any-branch-with-all-dbs.yml
+++ b/.github/workflows/build-any-branch-with-all-dbs.yml
@@ -12,6 +12,8 @@ on:
       - '**/*.adoc'
       - '**/*.md'
 
+permissions: {}
+
 env:
   MAVEN_COMMAND: ./mvnw
   MAVEN_CLI_COMMON: "-e -B"
@@ -24,14 +26,18 @@ jobs:
   compile-and-unit-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write  # advanced-security/maven-dependency-submission-action submits the dependency graph
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/jdk-setup
     - name: Compile and run unit tests
       run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} clean test
     - name: Submit dependencies to GitHub
       if: github.actor != 'dependabot[bot]'
-      uses: advanced-security/maven-dependency-submission-action@v6
+      uses: advanced-security/maven-dependency-submission-action@a64327a7329c9939cf675e458452febe1894a70c # v6.0.1
     - name: Upload target directory for reuse
       uses: actions/upload-artifact@v7
       with:
@@ -43,6 +49,8 @@ jobs:
     needs: [compile-and-unit-test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write  # advanced-security/maven-dependency-submission-action submits the dependency graph
     strategy:
       matrix:
         database: [
@@ -62,6 +70,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/jdk-setup
       - name: Download target directory
         uses: actions/download-artifact@v8
@@ -72,4 +82,4 @@ jobs:
         run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} -P${{ matrix.database.profile }} verify ${{ matrix.database.url != '' && format('-Ddbunit.profile.url={0}', matrix.database.url) || '' }}
       - name: Submit dependencies to GitHub
         if: github.actor != 'dependabot[bot]'
-        uses: advanced-security/maven-dependency-submission-action@v6
+        uses: advanced-security/maven-dependency-submission-action@a64327a7329c9939cf675e458452febe1894a70c # v6.0.1

--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true  # the "Commit and push" step below pushes with this credential
 
       # ---------------------------------------------------------------
       # 2. Fetch Dependabot metadata (skipped for manual dispatch).
@@ -128,14 +129,21 @@ jobs:
       # ---------------------------------------------------------------
       - name: Update changes.xml (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          PR_NUMBER: ${{ inputs.pr-number }}
+          DEPENDENCY_NAME: ${{ inputs.dependency-name }}
+          PREVIOUS_VERSION: ${{ inputs.previous-version }}
+          NEW_VERSION: ${{ inputs.new-version }}
+          UPDATE_TYPE: ${{ inputs.update-type }}
+          ECOSYSTEM: ${{ inputs.ecosystem }}
         run: |
           python3 .github/scripts/append-changes-entry.py \
-            --pr-number     "${{ inputs.pr-number }}" \
-            --dependency-name "${{ inputs.dependency-name }}" \
-            --previous-version "${{ inputs.previous-version }}" \
-            --new-version   "${{ inputs.new-version }}" \
-            --update-type   "${{ inputs.update-type }}" \
-            --ecosystem     "${{ inputs.ecosystem }}"
+            --pr-number       "${PR_NUMBER}" \
+            --dependency-name  "${DEPENDENCY_NAME}" \
+            --previous-version "${PREVIOUS_VERSION}" \
+            --new-version      "${NEW_VERSION}" \
+            --update-type      "${UPDATE_TYPE}" \
+            --ecosystem        "${ECOSYSTEM}"
 
       # ---------------------------------------------------------------
       # 4. Commit the updated changes.xml.

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,38 @@
+name: Submit dependencies
+
+# Runs only on trusted refs -- pushes to the default branch and manual
+# dispatch -- so the write-scoped token needed for the dependency graph
+# snapshot is never exposed to a build of pull-request or fork code.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'src/site/**'
+      - '**/*.adoc'
+      - '**/*.md'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_COMMAND: ./mvnw
+  MAVEN_CLI_COMMON: "-e -B"
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write  # submit the dependency graph snapshot
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/jdk-setup
+      - name: Submit dependencies to GitHub
+        uses: advanced-security/maven-dependency-submission-action@a64327a7329c9939cf675e458452febe1894a70c # v6.0.1

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,10 +1,17 @@
 name: Deploy Snapshot
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is safe here: the branches filter only matches runs on main
+  # (a fork PR's build runs under its own branch name), the job checks out the
+  # default branch rather than any attacker-controlled ref, and it consumes no
+  # artifact from the triggering run.
   workflow_run:
     workflows: ["Build any branch with all databases"]
     types: [completed]
     branches: [main]
+
+permissions: {}
 
 env:
   MAVEN_COMMAND: ./mvnw
@@ -15,8 +22,12 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read  # actions/checkout
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-java@v6.0.0
         with:
@@ -29,7 +40,7 @@ jobs:
 
       - name: Get project version
         id: ver
-        run: echo "version=$(${{ env.MAVEN_COMMAND }} help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+        run: echo "version=$(${{ env.MAVEN_COMMAND }} help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy snapshot to Maven Central
         if: endsWith(steps.ver.outputs.version, '-SNAPSHOT')
@@ -40,4 +51,6 @@ jobs:
 
       - name: Skip (not a snapshot version)
         if: "!endsWith(steps.ver.outputs.version, '-SNAPSHOT')"
-        run: echo "Version ${{ steps.ver.outputs.version }} is a release version — skipping snapshot deploy"
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: echo "Version ${VERSION} is a release version — skipping snapshot deploy"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,53 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/**'
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC — surface newly added lint rules and freshly deprecated actions
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          version: 1.7.12  # pin the tool; the action otherwise resolves 'latest' at run time
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          version: 1.30.1  # pin the tool rather than riding the action's 'latest'
+          advanced-security: false
+          annotations: true
+          persona: regular
+          collect: all
+          inputs: .github/

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,15 +8,17 @@ on:
       - 'src/site/**'
       - '**/*.adoc'
       - '**/*.md'
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is safe here: the branches filter only matches runs on main
+  # (a fork PR's build runs under its own branch name), the job checks out the
+  # default branch rather than any attacker-controlled ref, and it consumes no
+  # artifact from the triggering run.
   workflow_run:
     workflows: ["Build any branch with all databases", "Record Dependabot update in changes.xml"]
     types: [completed]
     branches: [ main ]
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -31,13 +33,17 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/jdk-setup
     - name: Build project
       run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} clean install -DskipTests
     - name: Generate Maven site
-      run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} site -Dproject.build.outputTimestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      run: ${{ env.MAVEN_COMMAND }} ${{ env.MAVEN_CLI_COMMON }} site -Dproject.build.outputTimestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     - name: Upload Pages artifact
       if: >-
         github.event_name == 'workflow_dispatch' ||
@@ -55,6 +61,9 @@ jobs:
       github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -17,5 +17,6 @@ rules:
       # Jul 2026). The workspace-relative `./...` form is used deliberately
       # until that syntax has settled; revisit and switch over later.
       - build-any-branch-with-all-dbs.yml
+      - dependency-submission.yml
       - publish-docs.yml
       - release.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,21 @@
+# zizmor configuration — see .github/workflows/lint-workflows.yml.
+# https://docs.zizmor.sh/configuration/
+rules:
+  unpinned-uses:
+    config:
+      # Symbolic (tag) refs are acceptable for actions published by GitHub's
+      # own organizations; anything else must be pinned to a full commit SHA.
+      policies:
+        "actions/*": ref-pin
+        "github/*": ref-pin
+        "dependabot/*": ref-pin
+        "*": hash-pin
+
+  self-repository:
+    ignore:
+      # The `$/...` self-repository syntax is only a few weeks old (GitHub,
+      # Jul 2026). The workspace-relative `./...` form is used deliberately
+      # until that syntax has settled; revisit and switch over later.
+      - build-any-branch-with-all-dbs.yml
+      - publish-docs.yml
+      - release.yml


### PR DESCRIPTION
## Summary by Sourcery

Harden GitHub automation security and add continuous linting for workflow configuration.

New Features:
- Add automated actionlint and zizmor checks for GitHub workflow changes, scheduled weekly and runnable manually.

Bug Fixes:
- Move dependency graph submission out of untrusted build workflows into a trusted default-branch workflow.
- Prevent workflow credentials from persisting after checkout and avoid exposing workflow inputs directly in shell commands.

Enhancements:
- Restrict GitHub Actions permissions to the minimum required at workflow and job scope.
- Add Dependabot cooldown periods for Maven and GitHub Actions updates.
- Configure documented exceptions and pin linting tools and third-party actions for workflow security checks.

CI:
- Harden CI and deployment workflows with explicit permissions, secure checkout settings, and safer shell handling.

Deployment:
- Scope GitHub Pages deployment permissions to the deployment job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated checks to validate GitHub Actions workflows for common security and configuration issues.
  - Improved workflow security by limiting permissions, preventing unnecessary credential persistence, and pinning third-party actions.
  - Added a dedicated workflow to submit Maven dependency information to GitHub.
  - Added safeguards and clearer configuration for releases, deployments, documentation publishing, and dependency updates.
  - Introduced cooldown periods for Maven and GitHub Actions updates.
  - Improved automated changelog commits and workflow input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->