### PR TITLE
feat(assertion): Add MultiDataSourcePrepAndExpectedTestCase for multi…

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <body>
-    <release version="3.6.0-SNAPSHOT" date="TBD" description="Annotation-driven test configuration for JUnit 5/6 (Jupiter) tests, row count check detecting test teardown missed or wrongly cleaned tables, a regular-expression ValueComparer, and a bundled prep/expected/verify test-data value type">
+    <release version="3.6.0-SNAPSHOT" date="TBD" description="Annotation-driven test configuration for JUnit 5/6 (Jupiter) tests, row count check detecting test teardown missed or wrongly cleaned tables, a regular-expression ValueComparer, a bundled prep/expected/verify test-data value type, and multi-data-source prep/verify support">
       <action dev="jeffjensen" type="add" issue="939" system="github" due-to="jeffjensen">
           Add an opt-in diagnostic that compares every table's row count before and after a test, failing the test when a count moved - catching a table the test left dirty, or a reference table it wrongly cleaned. Adds the org.dbunit.database.rowcount package (RowCounter, QueryPerTableRowCounter, RowCountSnapshot, RowCountDifference, RowCountCheck, RowCountChecker, RowCountCheckConfiguration, UnexpectedRowCountException) and the DatabaseConfig keys FEATURE_ROW_COUNT_CHECK (off by default), PROPERTY_ROW_COUNT_CHECK_EXCLUDE_TABLES, and PROPERTY_ROW_COUNTER.
       </action>
@@ -50,6 +50,9 @@
       </action>
       <action dev="jeffjensen" type="fix" issue="976" system="github" due-to="jeffjensen">
           Fix BytesDataType silently accepting an unrecognized [command] prefix on a binary column (BINARY, VARBINARY, LONGVARBINARY, BLOB): the [command] was dropped and the remainder stored as whatever it decoded to (URL, file, Base64, or raw UTF-8 bytes), so a value such as [NULL] left unreplaced by a ReplacementDataSet silently became empty bytes instead of failing. An unrecognized command now throws TypeCastException naming it and the four valid commands (TEXT, BASE64, FILE, URL). A value that starts with [ but has no closing ] does not match the command pattern and is unchanged, still treated as literal content.
+      </action>
+      <action dev="jeffjensen" type="add" issue="968" system="github" due-to="jeffjensen">
+          Add org.dbunit.MultiDataSourcePrepAndExpectedTestCase, wrapping an ordered {dataSourceName -> PrepAndExpectedTestCase} map of delegates so a test spanning two or more databases can prep, run its steps once, and verify every data source around that one run instead of hand-driving a second IDatabaseTester and reimplementing the setup/verify/cleanup/connection bookkeeping itself. Setup runs in declared order and teardown in reverse, driving each delegate only through its own preTest()/postTest(boolean) - never a reimplemented verify or cleanup - and a wired data source absent from a run's data map, or mapped to PrepAndExpectedTestData.NONE, sits that run out entirely with its connection never opened. A setup failure rolls back the data sources already set up (via postTest(false), not a bare cleanupData()) and rethrows the real failure with rollback failures suppressed onto it; every involved data source is still verified and cleaned up on postTest even after an earlier one fails, with every failure aggregated into the new org.dbunit.MultiDataSourceAssertionError (extends AssertionError, first failure as cause, the rest suppressed and labelled with their data source name and phase) instead of the first one stopping the rest from being torn down.
       </action>
     </release>
     <release version="3.5.2" date="Sep 7, 2026" description="DefaultPrepAndExpectedTestCase connection hygiene: replace a connection the pool or database dropped between tests, and warn when handed a non-autocommit connection">

--- a/src/main/java/org/dbunit/MultiDataSourceAssertionError.java
+++ b/src/main/java/org/dbunit/MultiDataSourceAssertionError.java
@@ -1,0 +1,150 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit;
+
+import java.util.List;
+
+/**
+ * Aggregates the {@link PrepAndExpectedTestCase#postTest(boolean)} failures a
+ * {@link MultiDataSourcePrepAndExpectedTestCase} collects across every involved data source,
+ * instead of stopping at the first one.
+ * <p>
+ * Extends {@link AssertionError} - not a checked exception, and not
+ * {@code org.opentest4j.MultipleFailuresError} - so a caller that already
+ * {@code assertThrows(AssertionError.class, ...)} around a single data source's
+ * {@link org.dbunit.assertion.DbComparisonFailure} keeps working whether one data source fails or
+ * several, and this class stays usable from a non-JUnit {@link PrepAndExpectedTestCase} delegate.
+ * <p>
+ * The first failure - in the wired data sources' declared order, not necessarily the reverse
+ * order they were torn down in - becomes this instance's {@linkplain #getCause() cause}, so it
+ * still surfaces one {@code Caused by:} hop below this instance, exactly as thrown by its
+ * delegate. Every other failure is {@linkplain #addSuppressed(Throwable) added as suppressed},
+ * labelled with its data source name and lifecycle phase so it reads without unwrapping.
+ *
+ * @author Jeff Jensen
+ * @since 3.6.0
+ */
+public class MultiDataSourceAssertionError extends AssertionError
+{
+    private static final long serialVersionUID = 1L;
+
+    private MultiDataSourceAssertionError(final String message, final Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    /**
+     * Builds the aggregate from one or more {@code postTest} failures: names every failing data
+     * source and its phase in the message, uses the first failure as this instance's cause, and
+     * attaches the rest as labelled suppressed exceptions.
+     *
+     * @param namedFailures
+     *            The failures to aggregate, in the order they should be named and reported; not
+     *            empty.
+     * @return The aggregate error.
+     */
+    static MultiDataSourceAssertionError aggregate(final List<NamedFailure> namedFailures)
+    {
+        final int failureCount = namedFailures.size();
+        final String message = makeMessage(failureCount, namedFailures);
+        return makeAggregateError(failureCount, message, namedFailures);
+    }
+
+    private static String makeMessage(final int failureCount, final List<NamedFailure> namedFailures)
+    {
+        final StringBuilder message = new StringBuilder();
+        appendCountPrefix(failureCount, message);
+        appendFailureDetails(failureCount, message, namedFailures);
+        return message.toString();
+    }
+
+    private static void appendCountPrefix(final int failureCount, final StringBuilder message)
+    {
+        final String plurality = failureCount == 1 ? "" : "s";
+        message.append(failureCount);
+        message.append(" data source");
+        message.append(plurality);
+        message.append(" failed in postTest: ");
+    }
+
+    private static void appendFailureDetails(final int failureCount, final StringBuilder message, final List<NamedFailure> namedFailures)
+    {
+        for (int i = 0; i < failureCount; i++)
+        {
+            if (i > 0)
+            {
+                message.append(", ");
+            }
+            final NamedFailure namedFailure = namedFailures.get(i);
+            message.append(namedFailure.dataSourceName);
+            message.append(" (");
+            message.append(namedFailure.phase);
+            message.append(')');
+        }
+    }
+
+    private static MultiDataSourceAssertionError makeAggregateError(final int failureCount, final String message, final List<NamedFailure> namedFailures)
+    {
+        final NamedFailure first = namedFailures.get(0);
+        final MultiDataSourceAssertionError aggregateError =
+                new MultiDataSourceAssertionError(message, first.failure);
+        for (int i = 1; i < failureCount; i++)
+        {
+            final NamedFailure other = namedFailures.get(i);
+            final DataSourceFailure dataSourceFailure =
+                    new DataSourceFailure(other.dataSourceName, other.phase, other.failure);
+            aggregateError.addSuppressed(dataSourceFailure);
+        }
+        return aggregateError;
+    }
+
+    /**
+     * One data source's {@link PrepAndExpectedTestCase#postTest(boolean)} failure, paired with
+     * the data source name and lifecycle phase {@link #aggregate(List)} reports it under.
+     */
+    static class NamedFailure
+    {
+        private final String dataSourceName;
+        private final String phase;
+        private final Throwable failure;
+
+        NamedFailure(final String dataSourceName, final String phase, final Throwable failure)
+        {
+            this.dataSourceName = dataSourceName;
+            this.phase = phase;
+            this.failure = failure;
+        }
+    }
+
+    /**
+     * Labels a data source's failure with its name and lifecycle phase, so an entry this class
+     * adds via {@link Throwable#addSuppressed(Throwable)} reads without unwrapping.
+     */
+    static class DataSourceFailure extends RuntimeException
+    {
+        private static final long serialVersionUID = 1L;
+
+        DataSourceFailure(final String dataSourceName, final String phase, final Throwable cause)
+        {
+            super(dataSourceName + " failed in " + phase + ".", cause);
+        }
+    }
+}

--- a/src/main/java/org/dbunit/MultiDataSourcePrepAndExpectedTestCase.java
+++ b/src/main/java/org/dbunit/MultiDataSourcePrepAndExpectedTestCase.java
@@ -1,0 +1,599 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.dbunit.util.fileloader.DataFileLoader;
+
+/**
+ * Preps and verifies tables across multiple {@link org.dbunit.database.IDatabaseConnection}s
+ * around one run of the code under test, by fanning the {@link PrepAndExpectedTestCase} lifecycle
+ * out to one delegate per data source.
+ * <p>
+ * Holds an ordered {@code {dataSourceName -> PrepAndExpectedTestCase}} map, one delegate per data
+ * source - normally a {@link DefaultPrepAndExpectedTestCase} bound to its own
+ * {@link IDatabaseTester}. {@link #preTest(Map)} sets each involved delegate up in the map's
+ * declared order; {@link #postTest(boolean)} verifies and cleans each up in reverse order,
+ * collecting every delegate's failure into one {@link MultiDataSourceAssertionError} instead of
+ * stopping at the first; {@link #runTest(Map, PrepAndExpectedTestCaseSteps)} runs the test steps
+ * exactly once in between. This class does not implement {@link PrepAndExpectedTestCase} itself -
+ * that interface's singular accessors and lifecycle methods have no honest answer for N data
+ * sources - and it drives each delegate only through that interface's own public
+ * {@code preTest}/{@code postTest} methods, never a reimplemented verify or cleanup.
+ * <p>
+ * The data source name to {@link PrepAndExpectedTestCase} wiring is fixed for this instance's
+ * life: assemble it with the constructors, {@link #from(String, PrepAndExpectedTestCase)}, the
+ * {@code forTesters(...)} factories, and {@link #add(String, PrepAndExpectedTestCase)} /
+ * {@link #add(String, IDatabaseTester)} / {@link #addAll(Map)}, all of which return this instance
+ * so they chain; the wiring is then frozen on the first {@link #preTest(Map)} /
+ * {@link #runTest(Map, PrepAndExpectedTestCaseSteps)} call, and a further {@code add} throws
+ * {@link IllegalStateException}. The {@code {dataSourceName -> PrepAndExpectedTestData}} map each
+ * test run passes to {@link #preTest(Map)} / {@link #runTest(Map, PrepAndExpectedTestCaseSteps)}
+ * varies per call; a wired data source absent from that map, or mapped to the exact
+ * {@link PrepAndExpectedTestData#NONE} instance, sits that run out entirely - its connection is
+ * never opened.
+ * <p>
+ * This instance is not thread-safe, but is safe to reuse sequentially - across
+ * {@code @ParameterizedTest} rows, or as a longer-lived singleton reused across test classes -
+ * since each {@link #preTest(Map)} / {@link #runTest(Map, PrepAndExpectedTestCaseSteps)} /
+ * {@link #postTest(boolean)} call, including its own teardown, completes before the next begins.
+ *
+ * @author Jeff Jensen
+ * @since 3.6.0
+ */
+public class MultiDataSourcePrepAndExpectedTestCase
+{
+    private final Map<String, PrepAndExpectedTestCase> testCasesByDataSourceName =
+            new LinkedHashMap<>();
+
+    private final DataFileLoader dataFileLoader;
+
+    private final boolean closeConnectionAfterTest;
+
+    private final boolean testerConstructionAllowed;
+
+    private boolean frozen;
+
+    private Set<String> involvedDataSourceNames = Collections.emptySet();
+
+    /**
+     * Creates an empty instance for the delegate currency: assemble it with
+     * {@link #add(String, PrepAndExpectedTestCase)} / {@link #addAll(Map)}.
+     */
+    public MultiDataSourcePrepAndExpectedTestCase()
+    {
+        this(null, true, false);
+    }
+
+    /**
+     * Creates an instance seeded with the given delegates, in the given map's iteration order.
+     *
+     * @param testCasesByDataSourceName
+     *            The delegates to seed this instance with, keyed by data source name; not
+     *            {@code null}, and not containing a {@code null} or blank key or a {@code null}
+     *            value. Defensively copied; mutating this map afterward does not affect this
+     *            instance.
+     * @throws IllegalArgumentException
+     *             If testCasesByDataSourceName is {@code null}, or contains a {@code null} or
+     *             blank key, or a {@code null} value.
+     */
+    public MultiDataSourcePrepAndExpectedTestCase(
+            final Map<String, ? extends PrepAndExpectedTestCase> testCasesByDataSourceName)
+    {
+        this();
+        addAll(testCasesByDataSourceName);
+    }
+
+    private MultiDataSourcePrepAndExpectedTestCase(final DataFileLoader dataFileLoader,
+            final boolean closeConnectionAfterTest, final boolean testerConstructionAllowed)
+    {
+        this.dataFileLoader = dataFileLoader;
+        this.closeConnectionAfterTest = closeConnectionAfterTest;
+        this.testerConstructionAllowed = testerConstructionAllowed;
+    }
+
+    /**
+     * Creates an instance seeded with one data source, for the delegate currency.
+     *
+     * @param dataSourceName
+     *            The data source name; not {@code null} or blank.
+     * @param testCase
+     *            The delegate for that data source; not {@code null}.
+     * @return The new instance, so further {@code add}/{@code addAll} calls can chain off it.
+     * @throws IllegalArgumentException
+     *             If dataSourceName is {@code null} or blank, or if testCase is {@code null}.
+     */
+    public static MultiDataSourcePrepAndExpectedTestCase from(final String dataSourceName,
+            final PrepAndExpectedTestCase testCase)
+    {
+        return new MultiDataSourcePrepAndExpectedTestCase().add(dataSourceName, testCase);
+    }
+
+    /**
+     * Creates an empty instance for the tester currency - {@link #add(String, IDatabaseTester)}
+     * wraps each tester in a {@link DefaultPrepAndExpectedTestCase} sharing the given loader, with
+     * {@code closeConnectionAfterTest} true.
+     *
+     * @param dataFileLoader
+     *            The loader every {@link #add(String, IDatabaseTester)}-wrapped delegate shares.
+     * @return The new instance.
+     */
+    public static MultiDataSourcePrepAndExpectedTestCase forTesters(
+            final DataFileLoader dataFileLoader)
+    {
+        return forTesters(dataFileLoader, true);
+    }
+
+    /**
+     * Creates an empty instance for the tester currency, as {@link #forTesters(DataFileLoader)}
+     * does, with the given {@code closeConnectionAfterTest} applied to every
+     * {@link #add(String, IDatabaseTester)}-wrapped delegate.
+     *
+     * @param dataFileLoader
+     *            The loader every {@link #add(String, IDatabaseTester)}-wrapped delegate shares.
+     * @param closeConnectionAfterTest
+     *            Whether each {@link #add(String, IDatabaseTester)}-wrapped delegate closes its
+     *            connection after each test; false to reuse each delegate's connection across
+     *            {@code @ParameterizedTest} rows, as for a lone {@link DefaultPrepAndExpectedTestCase}.
+     * @return The new instance.
+     */
+    public static MultiDataSourcePrepAndExpectedTestCase forTesters(
+            final DataFileLoader dataFileLoader, final boolean closeConnectionAfterTest)
+    {
+        return new MultiDataSourcePrepAndExpectedTestCase(dataFileLoader,
+                closeConnectionAfterTest, true);
+    }
+
+    /**
+     * Creates an instance for the tester currency, seeded with the given testers - as
+     * {@link #forTesters(DataFileLoader)} does, then {@link #add(String, IDatabaseTester)} for
+     * each entry, in the given map's iteration order.
+     *
+     * @param dataFileLoader
+     *            The loader every wrapped delegate shares.
+     * @param testersByDataSourceName
+     *            The testers to seed this instance with, keyed by data source name; not
+     *            {@code null}.
+     * @return The new instance.
+     * @throws IllegalArgumentException
+     *             If testersByDataSourceName is {@code null}, or contains a {@code null} or
+     *             blank key, or a {@code null} value.
+     */
+    public static MultiDataSourcePrepAndExpectedTestCase forTesters(
+            final DataFileLoader dataFileLoader,
+            final Map<String, ? extends IDatabaseTester> testersByDataSourceName)
+    {
+        return forTesters(dataFileLoader, testersByDataSourceName, true);
+    }
+
+    /**
+     * Creates an instance for the tester currency, seeded with the given testers, as
+     * {@link #forTesters(DataFileLoader, Map)} does, with the given
+     * {@code closeConnectionAfterTest} applied to every wrapped delegate.
+     *
+     * @param dataFileLoader
+     *            The loader every wrapped delegate shares.
+     * @param testersByDataSourceName
+     *            The testers to seed this instance with, keyed by data source name; not
+     *            {@code null}.
+     * @param closeConnectionAfterTest
+     *            Whether each wrapped delegate closes its connection after each test.
+     * @return The new instance.
+     * @throws IllegalArgumentException
+     *             If testersByDataSourceName is {@code null}, or contains a {@code null} or
+     *             blank key, or a {@code null} value.
+     */
+    public static MultiDataSourcePrepAndExpectedTestCase forTesters(
+            final DataFileLoader dataFileLoader,
+            final Map<String, ? extends IDatabaseTester> testersByDataSourceName,
+            final boolean closeConnectionAfterTest)
+    {
+        if (testersByDataSourceName == null)
+        {
+            throw new IllegalArgumentException("testersByDataSourceName must not be null.");
+        }
+
+        final MultiDataSourcePrepAndExpectedTestCase instance =
+                forTesters(dataFileLoader, closeConnectionAfterTest);
+        for (final Map.Entry<String, ? extends IDatabaseTester> entry : testersByDataSourceName
+                .entrySet())
+        {
+            instance.add(entry.getKey(), entry.getValue());
+        }
+        return instance;
+    }
+
+    /**
+     * Wires one data source to the given delegate.
+     *
+     * @param dataSourceName
+     *            The data source name; not {@code null} or blank, and not already wired.
+     * @param testCase
+     *            The delegate for that data source; not {@code null}.
+     * @return This instance, so calls can chain.
+     * @throws IllegalArgumentException
+     *             If dataSourceName is {@code null}, blank, or already wired, or if testCase is
+     *             {@code null}.
+     * @throws IllegalStateException
+     *             If the wiring is already frozen by an earlier {@link #preTest(Map)} /
+     *             {@link #runTest(Map, PrepAndExpectedTestCaseSteps)} call.
+     */
+    public MultiDataSourcePrepAndExpectedTestCase add(final String dataSourceName,
+            final PrepAndExpectedTestCase testCase)
+    {
+        checkNotFrozen();
+        if (dataSourceName == null || dataSourceName.trim().isEmpty())
+        {
+            throw new IllegalArgumentException("dataSourceName must not be null or blank.");
+        }
+        if (testCase == null)
+        {
+            throw new IllegalArgumentException("testCase must not be null.");
+        }
+        if (testCasesByDataSourceName.containsKey(dataSourceName))
+        {
+            throw new IllegalArgumentException(
+                    "A data source named '" + dataSourceName + "' is already wired.");
+        }
+
+        testCasesByDataSourceName.put(dataSourceName, testCase);
+        return this;
+    }
+
+    /**
+     * Wires one data source to a new {@link DefaultPrepAndExpectedTestCase} bound to the given
+     * tester, sharing this instance's loader and {@code closeConnectionAfterTest}.
+     *
+     * @param dataSourceName
+     *            The data source name; not {@code null} or blank, and not already wired.
+     * @param tester
+     *            The tester for that data source; not {@code null}.
+     * @return This instance, so calls can chain.
+     * @throws IllegalArgumentException
+     *             If dataSourceName is {@code null}, blank, or already wired, or if tester is
+     *             {@code null}.
+     * @throws IllegalStateException
+     *             If this instance was not created via one of the {@code forTesters(...)}
+     *             factories, or if the wiring is already frozen.
+     */
+    public MultiDataSourcePrepAndExpectedTestCase add(final String dataSourceName,
+            final IDatabaseTester tester)
+    {
+        checkNotFrozen();
+        if (!testerConstructionAllowed)
+        {
+            throw new IllegalStateException("add(String, IDatabaseTester) requires an instance"
+                    + " created via one of the forTesters(...) factories.");
+        }
+        if (tester == null)
+        {
+            throw new IllegalArgumentException("tester must not be null.");
+        }
+
+        return add(dataSourceName,
+                new DefaultPrepAndExpectedTestCase(dataFileLoader, tester,
+                        closeConnectionAfterTest));
+    }
+
+    /**
+     * Wires every entry of the given map, in its iteration order.
+     *
+     * @param testCasesByDataSourceName
+     *            The delegates to add, keyed by data source name; not {@code null}.
+     * @return This instance, so calls can chain.
+     * @throws IllegalArgumentException
+     *             If testCasesByDataSourceName is {@code null}, or contains a {@code null} or
+     *             blank key, an already-wired key, or a {@code null} value.
+     * @throws IllegalStateException
+     *             If the wiring is already frozen by an earlier {@link #preTest(Map)} /
+     *             {@link #runTest(Map, PrepAndExpectedTestCaseSteps)} call.
+     */
+    public MultiDataSourcePrepAndExpectedTestCase addAll(
+            final Map<String, ? extends PrepAndExpectedTestCase> testCasesByDataSourceName)
+    {
+        checkNotFrozen();
+        if (testCasesByDataSourceName == null)
+        {
+            throw new IllegalArgumentException("testCasesByDataSourceName must not be null.");
+        }
+
+        for (final Map.Entry<String, ? extends PrepAndExpectedTestCase> entry
+                : testCasesByDataSourceName.entrySet())
+        {
+            add(entry.getKey(), entry.getValue());
+        }
+        return this;
+    }
+
+    /**
+     * Runs the full lifecycle once: {@link #preTest(Map)}, then the given test steps exactly
+     * once, then {@link #postTest(boolean) postTest(true)}.
+     * <p>
+     * A throwable from the test steps is rethrown as-is - not wrapped - with every involved
+     * delegate torn down first via {@link PrepAndExpectedTestCase#postTest(boolean)
+     * postTest(false)} in reverse declared order, each teardown failure attached to the step
+     * throwable via {@link Throwable#addSuppressed(Throwable)} - except a teardown failure that
+     * is the exact same instance as the step throwable itself, which is dropped rather than
+     * attempting the self-suppression {@link Throwable#addSuppressed(Throwable)} forbids.
+     *
+     * @param dataByDataSourceName
+     *            The prep/expected/verify data for this run, keyed by data source name; a wired
+     *            data source absent from this map, or mapped to {@link PrepAndExpectedTestData#NONE},
+     *            sits this run out entirely.
+     * @param testSteps
+     *            The test steps to run, exactly once.
+     * @return The user-defined object the test steps returned.
+     * @throws Exception
+     *             If {@link #preTest(Map)} fails, if the test steps fail, or if
+     *             {@link #postTest(boolean)} fails.
+     */
+    public Object runTest(final Map<String, PrepAndExpectedTestData> dataByDataSourceName,
+            final PrepAndExpectedTestCaseSteps testSteps) throws Exception
+    {
+        preTest(dataByDataSourceName);
+
+        final Object result;
+        try
+        {
+            result = testSteps.run();
+        } catch (final Throwable stepFailure)
+        {
+            tearDownSuppressing(reverseInvolvedOrder(), stepFailure);
+            throw stepFailure;
+        }
+
+        postTest(true);
+        return result;
+    }
+
+    /**
+     * Sets up every involved data source's prep data, in declared order.
+     * <p>
+     * A wired data source absent from {@code dataByDataSourceName}, or mapped to the exact
+     * {@link PrepAndExpectedTestData#NONE} instance, is skipped entirely this run - its
+     * {@code preTest} is never called and its connection is never opened. An unknown key in
+     * {@code dataByDataSourceName} - one not wired to this instance - is rejected before any
+     * delegate is touched.
+     * <p>
+     * If an involved delegate's own {@code preTest} fails, every involved delegate set up so far -
+     * including the one that just failed - is rolled back, via
+     * {@link PrepAndExpectedTestCase#postTest(boolean) postTest(false)}, in reverse order, never a
+     * bare {@code cleanupData()} - with each rollback failure attached to the original failure via
+     * {@link Throwable#addSuppressed(Throwable)}, except a rollback failure that is the exact same
+     * instance as the original failure, which is dropped rather than attempting the
+     * self-suppression {@link Throwable#addSuppressed(Throwable)} forbids; the original failure is
+     * then rethrown as-is.
+     *
+     * @param dataByDataSourceName
+     *            The prep/expected/verify data for this run, keyed by data source name; not
+     *            {@code null}, and containing no key this instance has no delegate wired for.
+     * @throws IllegalStateException
+     *             If no data source is wired yet.
+     * @throws IllegalArgumentException
+     *             If dataByDataSourceName is {@code null}, contains an unknown data source name,
+     *             or maps a wired data source name to {@code null}.
+     * @throws Exception
+     *             If an involved delegate's own {@code preTest} fails.
+     */
+    public void preTest(final Map<String, PrepAndExpectedTestData> dataByDataSourceName)
+            throws Exception
+    {
+        if (testCasesByDataSourceName.isEmpty())
+        {
+            throw new IllegalStateException(
+                    "No data source is wired; call add(...) before preTest(...).");
+        }
+        if (dataByDataSourceName == null)
+        {
+            throw new IllegalArgumentException("dataByDataSourceName must not be null.");
+        }
+
+        final Set<String> unknownDataSourceNames = new LinkedHashSet<>(
+                dataByDataSourceName.keySet());
+        unknownDataSourceNames.removeAll(testCasesByDataSourceName.keySet());
+        if (!unknownDataSourceNames.isEmpty())
+        {
+            throw new IllegalArgumentException("Unknown data source name(s) "
+                    + unknownDataSourceNames + "; wired data source(s) are "
+                    + testCasesByDataSourceName.keySet() + ".");
+        }
+
+        final Set<String> involved = new LinkedHashSet<>();
+        for (final String dataSourceName : testCasesByDataSourceName.keySet())
+        {
+            final boolean hasEntry = dataByDataSourceName.containsKey(dataSourceName);
+            final PrepAndExpectedTestData data = dataByDataSourceName.get(dataSourceName);
+            if (hasEntry && data == null)
+            {
+                throw new IllegalArgumentException("dataByDataSourceName must not map \""
+                        + dataSourceName + "\" to null; omit the key or map it to"
+                        + " PrepAndExpectedTestData.NONE to skip that data source.");
+            }
+            if (data != null && data != PrepAndExpectedTestData.NONE)
+            {
+                involved.add(dataSourceName);
+            }
+        }
+
+        frozen = true;
+        final List<String> setUpSoFar = new ArrayList<>();
+        for (final String dataSourceName : involved)
+        {
+            final PrepAndExpectedTestData data = dataByDataSourceName.get(dataSourceName);
+            final PrepAndExpectedTestCase testCase = testCasesByDataSourceName.get(dataSourceName);
+            try
+            {
+                testCase.preTest(data.getVerifyTableDefinitions(), data.getPrepDataFiles(),
+                        data.getExpectedDataFiles());
+            } catch (final Throwable setupFailure)
+            {
+                setUpSoFar.add(dataSourceName);
+                rollBackSuppressing(setUpSoFar, setupFailure);
+                involvedDataSourceNames = Collections.emptySet();
+                throw setupFailure;
+            }
+            setUpSoFar.add(dataSourceName);
+        }
+
+        involvedDataSourceNames = involved;
+    }
+
+    private void rollBackSuppressing(final List<String> setUpSoFar, final Throwable primaryFailure)
+    {
+        final List<String> reverseOrder = new ArrayList<>(setUpSoFar);
+        Collections.reverse(reverseOrder);
+        tearDownSuppressing(reverseOrder, primaryFailure);
+    }
+
+    private void tearDownSuppressing(final List<String> dataSourceNamesInTeardownOrder,
+            final Throwable primaryFailure)
+    {
+        for (final String dataSourceName : dataSourceNamesInTeardownOrder)
+        {
+            try
+            {
+                testCasesByDataSourceName.get(dataSourceName).postTest(false);
+            } catch (final Throwable teardownFailure)
+            {
+                // Throwable.addSuppressed() throws IllegalArgumentException for
+                // self-suppression; skip it rather than let that mask the real failure.
+                if (teardownFailure != primaryFailure)
+                {
+                    primaryFailure.addSuppressed(teardownFailure);
+                }
+            }
+        }
+    }
+
+    /**
+     * Verifies and cleans up every involved data source, in reverse declared order.
+     * <p>
+     * Every involved delegate's own {@link PrepAndExpectedTestCase#postTest(boolean)} runs -
+     * verify (or, when {@code verifyData} is false, its own row count baseline discard) and
+     * cleanup - even if an earlier one in this reverse order failed; every collected failure is
+     * then aggregated into one {@link MultiDataSourceAssertionError} rather than the first one
+     * stopping the rest from being torn down.
+     *
+     * @param verifyData
+     *            True to verify each involved delegate's data before cleaning it up; false to
+     *            skip verification (the test steps already failed) and just clean up.
+     * @throws MultiDataSourceAssertionError
+     *             If one or more involved delegates failed their own {@code postTest}.
+     */
+    public void postTest(final boolean verifyData) throws Exception
+    {
+        final Map<String, Throwable> failuresByDataSourceName = new LinkedHashMap<>();
+        for (final String dataSourceName : reverseInvolvedOrder())
+        {
+            try
+            {
+                testCasesByDataSourceName.get(dataSourceName).postTest(verifyData);
+            } catch (final Throwable failure)
+            {
+                failuresByDataSourceName.put(dataSourceName, failure);
+            }
+        }
+
+        if (failuresByDataSourceName.isEmpty())
+        {
+            return;
+        }
+
+        final List<MultiDataSourceAssertionError.NamedFailure> namedFailures = new ArrayList<>();
+        for (final String dataSourceName : testCasesByDataSourceName.keySet())
+        {
+            final Throwable failure = failuresByDataSourceName.get(dataSourceName);
+            if (failure != null)
+            {
+                namedFailures.add(new MultiDataSourceAssertionError.NamedFailure(dataSourceName,
+                        phaseOf(verifyData, failure), failure));
+            }
+        }
+        throw MultiDataSourceAssertionError.aggregate(namedFailures);
+    }
+
+    // Only an AssertionError reliably means the verify step failed - a checked exception (e.g. a
+    // DataSetException from a malformed dataset) could equally have come from cleanupData(), so
+    // it is labelled generically rather than guessed wrong.
+    private static String phaseOf(final boolean verifyData, final Throwable failure)
+    {
+        if (!verifyData)
+        {
+            return "cleanupData";
+        }
+        return failure instanceof AssertionError ? "verifyData" : "postTest";
+    }
+
+    private List<String> reverseInvolvedOrder()
+    {
+        final List<String> reverseOrder = new ArrayList<>(involvedDataSourceNames);
+        Collections.reverse(reverseOrder);
+        return reverseOrder;
+    }
+
+    private void checkNotFrozen()
+    {
+        if (frozen)
+        {
+            throw new IllegalStateException(
+                    "The data source wiring is frozen after the first preTest(...)/runTest(...)"
+                            + " call; assemble it fully before running a test.");
+        }
+    }
+
+    /**
+     * Returns the wired data source names, in declared order.
+     *
+     * @return An unmodifiable view of the wired data source names, in declared order.
+     */
+    public Set<String> getDataSourceNames()
+    {
+        return Collections.unmodifiableSet(testCasesByDataSourceName.keySet());
+    }
+
+    /**
+     * Returns the delegate wired to one data source, for a test that needs to reach one directly -
+     * e.g. to assert something extra on it, or to inspect it after a failure.
+     *
+     * @param dataSourceName
+     *            The data source name.
+     * @return The delegate wired to that data source.
+     * @throws IllegalArgumentException
+     *             If no data source with that name is wired.
+     */
+    public PrepAndExpectedTestCase getTestCase(final String dataSourceName)
+    {
+        final PrepAndExpectedTestCase testCase = testCasesByDataSourceName.get(dataSourceName);
+        if (testCase == null)
+        {
+            throw new IllegalArgumentException(
+                    "No data source named '" + dataSourceName + "' is wired.");
+        }
+        return testCase;
+    }
+}

--- a/src/site/asciidoc/index.adoc
+++ b/src/site/asciidoc/index.adoc
@@ -54,8 +54,9 @@ link:testcases/annotations.html[*annotation-driven test configuration*] for JUni
 an opt-in link:components/rowcountcheck.html[*row count check*] that catches teardown table cleanup mistakes,
 link:datasets/fileloader.html[*JSON/YAML* data file loader] implementations,
 link:datacomparisons/valuecomparer.html[`RegularExpressionValueComparer`] for *matching a column against a pattern* rather than a literal,
+link:testcases/PrepAndExpectedTestCase.html#Bundling_Test_Data[`PrepAndExpectedTestData`] - an *immutable bundle* of the verify-definition, prep, and expected arrays for data-driven `PrepAndExpectedTestCase` tests,
 and
-link:testcases/PrepAndExpectedTestCase.html#Bundling_Test_Data[`PrepAndExpectedTestData`] - an *immutable bundle* of the verify-definition, prep, and expected arrays for data-driven `PrepAndExpectedTestCase` tests.
+link:testcases/MultiDataSourcePrepAndExpectedTestCase.html[`MultiDataSourcePrepAndExpectedTestCase`] for prepping and verifying *multiple databases* around one test.
 See link:https://dbunit.github.io/dbunit-extension/repos.html#snapshots[SNAPSHOTS] for how to use them.
 Refer to the link:changes.html#a3.6.0-SNAPSHOT[changes report],
 the link:https://github.com/dbunit/dbunit-extension/issues?q=is%3Aissue+milestone%3A3.6.0%20type%3AFeature[feature list], and

--- a/src/site/asciidoc/testcases.adoc
+++ b/src/site/asciidoc/testcases.adoc
@@ -36,6 +36,12 @@ packages prep/verify/cleanup behind `runTest()`, needs no parent class, and
 works with both styles (it holds an `IDatabaseTester`, so it composes either
 way).
 
+When a single test needs to prep and verify tables across *more than one* database around one run
+of the code under test, wrap multiple `PrepAndExpectedTestCase` delegates — one per data source —
+in
+link:testcases/MultiDataSourcePrepAndExpectedTestCase.html[MultiDataSourcePrepAndExpectedTestCase]
+rather than hand-driving each one separately.
+
 == Inheritance: DBTestCase and Its Subclasses
 
 `DBTestCase` extends the top-level `DatabaseTestCase`. A template method,

--- a/src/site/asciidoc/testcases/MultiDataSourcePrepAndExpectedTestCase.adoc
+++ b/src/site/asciidoc/testcases/MultiDataSourcePrepAndExpectedTestCase.adoc
@@ -1,0 +1,229 @@
+= MultiDataSourcePrepAndExpectedTestCase
+Jeff Jensen
+
+== Overview
+
+A test that exercises code spanning two or more databases - an "orders" database and an
+"inventory" database, say - has no way to prep and verify tables in *each* database around one
+run of the code under test using a single
+link:PrepAndExpectedTestCase.html[PrepAndExpectedTestCase]. Hand-driving a second
+`IDatabaseTester` and reimplementing the setup/verify/cleanup/connection bookkeeping is
+error-prone: on a failed setup, the earlier data source's rollback must call `postTest(false)`,
+not a bare `cleanupData()`, or its own row count check fires against a half-set-up, unknown-state
+database and buries the real cause.
+
+link:../apidocs/org/dbunit/MultiDataSourcePrepAndExpectedTestCase.html[MultiDataSourcePrepAndExpectedTestCase]
+wraps an ordered `{dataSourceName -> PrepAndExpectedTestCase}` map of delegates - normally one
+link:../apidocs/org/dbunit/DefaultPrepAndExpectedTestCase.html[DefaultPrepAndExpectedTestCase] per
+data source - and runs the same prep -> steps -> verify -> cleanup lifecycle, fanning setup and
+teardown out to every delegate through each delegate's own `preTest`/`postTest`, while running the
+test steps *exactly once*. It does not implement `PrepAndExpectedTestCase` itself: that
+interface's singular accessors and lifecycle methods have no honest answer for N data sources. It
+is a peer type with a parallel, map-keyed API, plus a `getTestCase(name)` escape hatch to one
+delegate.
+
+=== Wiring versus data
+
+Two things vary on two different schedules:
+
+Wiring (fixed for the instance's life):: the `{name -> PrepAndExpectedTestCase}` (or
+`{name -> IDatabaseTester}`) map, assembled with the constructors,
+`from(String, PrepAndExpectedTestCase)`, the `forTesters(...)` factories, and `add`/`addAll` -
+each returning the instance so calls chain - then frozen on the first `preTest`/`runTest` call.
+
+Data (varies per test method, per `@ParameterizedTest` row):: the
+`{name -> PrepAndExpectedTestData}` map passed to `preTest(map)`/`runTest(map, steps)`. A wired
+data source can sit a given run out entirely by being absent from this map, or mapped to the exact
+`PrepAndExpectedTestData.NONE` instance - its connection is then never opened.
+
+=== Before - a hand-driven second tester
+
+[source,java]
+----
+private DefaultPrepAndExpectedTestCase orders;
+private DefaultPrepAndExpectedTestCase inventory;
+
+@Test
+void testTransfer_success_movesStockAndRecordsOrder() throws Exception
+{
+    orders.configureTest(ORDERS_VERIFY, ORDERS_PREP, ORDERS_EXPECTED);
+    inventory.configureTest(INV_VERIFY, INV_PREP, INV_EXPECTED);
+    orders.preTest();
+    inventory.preTest();
+    try
+    {
+        service.transfer(orderId);           // writes to both databases
+        orders.verifyData();                 // first mismatch hides the second
+        inventory.verifyData();
+    }
+    finally
+    {
+        // reverse order, both, suppressed exceptions - and postTest(false), not
+        // cleanupData(), on a failed run
+        inventory.cleanupData();
+        orders.cleanupData();
+    }
+}
+----
+
+=== After - the wrapper
+
+[source,java]
+----
+private MultiDataSourcePrepAndExpectedTestCase testCase;
+
+@BeforeEach
+void setUp()
+{
+    final Map<String, IDatabaseTester> testers = new LinkedHashMap<>();
+    testers.put("orders", makeTester(ordersDataSource));
+    testers.put("inventory", makeTester(inventoryDataSource));
+    testCase = MultiDataSourcePrepAndExpectedTestCase.forTesters(loader, testers);
+}
+
+@Test
+void testTransfer_success_movesStockAndRecordsOrder() throws Exception
+{
+    final Map<String, PrepAndExpectedTestData> data = new LinkedHashMap<>();
+    data.put("orders", new PrepAndExpectedTestData(ORDERS_VERIFY, ORDERS_PREP, ORDERS_EXPECTED));
+    data.put("inventory", new PrepAndExpectedTestData(INV_VERIFY, INV_PREP, INV_EXPECTED));
+    testCase.runTest(data, () ->
+    {
+        service.transfer(orderId);
+        return null;
+    });
+}
+----
+
+Setup order, reverse teardown, verify-every-source-then-report, `postTest(false)` (not a bare
+cleanup) on a failed run, and suppressed-exception handling are all the wrapper's job.
+
+=== Orchestration rules
+
+[cols="1,1,3", options="header"]
+|===
+|Phase |Order |Behavior
+
+|`preTest(map)`
+|declared
+|An unknown key, or a key mapped to `null`, throws before any delegate is touched. For each
+ *involved* data source (present in the map and not mapped to `NONE`), in declared order:
+ `delegate.preTest(...)`. If one throws, every involved delegate set up so far - including the one
+ that just failed - is rolled back via `postTest(false)` in reverse - never a bare `cleanupData()`
+ - with each rollback failure attached as suppressed on the original failure, which is then
+ rethrown as-is.
+
+|test steps
+|once
+|Run by `runTest`, or by the caller between `preTest(map)` and `postTest(boolean)`. A delegate's
+ own overridden `runTestSteps()` is not invoked - the steps span every data source, so no single
+ delegate's step wrapper is the right scope.
+
+|`postTest(verify)`
+|reverse
+|`delegate.postTest(verify)` for each involved delegate, in reverse declared order, even after an
+ earlier one in that order fails - so every data source is verified and cleaned up, and every
+ mismatch reported, instead of stopping at the first. Every collected failure is aggregated into
+ one link:../apidocs/org/dbunit/MultiDataSourceAssertionError.html[MultiDataSourceAssertionError].
+|===
+
+`MultiDataSourceAssertionError` extends `AssertionError` (not a checked exception, and not
+`org.opentest4j.MultipleFailuresError`, keeping this core class JUnit-independent): the first
+failure becomes its cause, so a single failing data source still surfaces its real
+link:../apidocs/org/dbunit/assertion/DbComparisonFailure.html[DbComparisonFailure] one
+`Caused by:` hop down, and the rest are attached as suppressed, each labelled with its data source
+name and phase, e.g. `"2 data sources failed in postTest: orders (verifyData), inventory
+(cleanupData)"`.
+
+=== A `@ParameterizedTest` suite
+
+Condensed from PrepAndExpectedTestCase's
+link:PrepAndExpectedTestCase.html#Bundling_Test_Data[Bundling Prep, Expected, and Verify Into One
+Argument] section: one `PrepAndExpectedTestData` per data source per scenario, collected into one
+`Map<String, PrepAndExpectedTestData>` per `@MethodSource` row.
+
+[source,java]
+----
+@ParameterizedTest(name = "[{index}] {0}")
+@MethodSource("testData")
+void test(String testName, Map<String, PrepAndExpectedTestData> rowData, long customerId,
+        String sku, int quantity) throws Exception
+{
+    testCase.runTest(rowData, () -> {
+        orderService.placeOrder(customerId, sku, quantity);
+        return null;
+    });
+}
+
+private static Map<String, PrepAndExpectedTestData> data(PrepAndExpectedTestData catalog,
+        PrepAndExpectedTestData orders, PrepAndExpectedTestData inventory)
+{
+    Map<String, PrepAndExpectedTestData> map = new LinkedHashMap<>();
+    map.put("catalog", catalog);
+    map.put("orders", orders);
+    map.put("inventory", inventory);
+    return map;
+}
+
+private static Object[][] testData()
+{
+    return new Object[][] {
+            {"in stock", data(CATALOG_SOLD, ORDER_INSERTED, STOCK_DRAWN_DOWN), 42L, "WIDGET-1", 3},
+    };
+}
+----
+
+A row may omit a data source, or pass `PrepAndExpectedTestData.NONE` for it, to leave it out of
+that run entirely.
+
+=== Replacing a hand-rolled multi-tester harness
+
+A suite that already hand-rolls this pattern - two or more `@Qualifier`-injected
+`PrepAndExpectedTestCase` delegates wired into a component, a per-scenario record shaped like
+`PrepAndExpectedTestData`, and hand-coded pre/run/post fan-out with its own aggregate exception -
+can delegate the dbUnit fan-out to this wrapper directly:
+
+[source,java]
+----
+public class PrimarySecondaryDbTester
+{
+    private final MultiDataSourcePrepAndExpectedTestCase testCase;
+
+    public PrimarySecondaryDbTester(
+            @Qualifier("primaryTestCase") PrepAndExpectedTestCase primaryTestCase,
+            @Qualifier("secondaryTestCase") PrepAndExpectedTestCase secondaryTestCase)
+    {
+        testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("primary", primaryTestCase)
+                .add("secondary", secondaryTestCase);
+    }
+
+    public Object runTest(PrepAndExpectedTestData primary, PrepAndExpectedTestData secondary,
+            PrepAndExpectedTestCaseSteps testSteps) throws Exception
+    {
+        final Map<String, PrepAndExpectedTestData> data = new LinkedHashMap<>();
+        data.put("primary", primary);
+        data.put("secondary", secondary);
+        return testCase.runTest(data, testSteps);
+    }
+}
+----
+
+The harness's own case list, per-case fan-out methods, and aggregate exception type are all
+deleted; `MultiDataSourcePrepAndExpectedTestCase` owns that logic now, and the aggregate becomes
+unchecked, so a `throws Throwable` a caller declared for the old checked aggregate keeps compiling
+and can be narrowed as a later cleanup. Two things to check before switching: a scenario that
+intentionally preps/verifies *nothing* for one side but still wants that delegate's connection
+opened must build its own all-empty `PrepAndExpectedTestData` rather than pass `NONE` - the skip
+check is `==` against that exact instance, not content equality; and teardown order flips from
+whatever the harness used to reverse declared order, harmless when, as is typical, the data
+sources are independent.
+
+This wrapper's API is deliberately the *programmatic* equivalent only. A named-tester /
+named-connection annotation model for the `@DbUnitPrep`/`@DbUnitExpected` annotation style
+described in PrepAndExpectedTestCase's
+link:PrepAndExpectedTestCase.html#Annotation_Driven_Equivalent[Annotation-Driven Equivalent]
+section, extended to multiple data sources, is tracked separately as
+https://github.com/dbunit/dbunit-extension/issues/969[issue #969]. Until that lands, a
+`@ParameterizedTest` using the programmatic API above is the way to cover multiple data sources in
+one test.

--- a/src/site/asciidoc/testcases/PrepAndExpectedTestCase.adoc
+++ b/src/site/asciidoc/testcases/PrepAndExpectedTestCase.adoc
@@ -915,3 +915,10 @@ public void testExample() throws Exception
     }
 }
 ----
+
+== See Also
+
+A test exercising code that spans two or more databases can prep and verify each database around
+one run of the code under test with
+link:MultiDataSourcePrepAndExpectedTestCase.html[MultiDataSourcePrepAndExpectedTestCase], which
+wraps one `PrepAndExpectedTestCase` delegate per data source.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -53,14 +53,15 @@
       <item name="dbUnit in 5 Minutes"  href="/fiveminutes.html"/>
       <item name="Getting Started"      href="/howto.html"/>
       <item name="Test Integration"     href="/testcases.html">
-        <item name="IDatabaseTester Guide"        href="/testcases/IDatabaseTester.html"/>
-        <item name="DbUnitExtension"              href="/testcases/DbUnitExtension.html"/>
-        <item name="Annotations"                  href="/testcases/annotations.html"/>
-        <item name="PrepAndExpectedTestCase"      href="/testcases/PrepAndExpectedTestCase.html"/>
-        <item name="JdbcBasedDBTestCase"          href="/testcases/JdbcBasedDBTestCase.html"/>
-        <item name="DataSourceBasedDBTestCase"    href="/testcases/DataSourceBasedDBTestCase.html"/>
-        <item name="JndiBasedDBTestCase"          href="/testcases/JndiBasedDBTestCase.html"/>
-        <item name="Migrating to IDatabaseTester" href="/testcases/MigratingToIDatabaseTester.html"/>
+        <item name="IDatabaseTester Guide"                  href="/testcases/IDatabaseTester.html"/>
+        <item name="DbUnitExtension"                        href="/testcases/DbUnitExtension.html"/>
+        <item name="Annotations"                            href="/testcases/annotations.html"/>
+        <item name="PrepAndExpectedTestCase"                href="/testcases/PrepAndExpectedTestCase.html"/>
+        <item name="MultiDataSourcePrepAndExpectedTestCase" href="/testcases/MultiDataSourcePrepAndExpectedTestCase.html"/>
+        <item name="JdbcBasedDBTestCase"                    href="/testcases/JdbcBasedDBTestCase.html"/>
+        <item name="DataSourceBasedDBTestCase"              href="/testcases/DataSourceBasedDBTestCase.html"/>
+        <item name="JndiBasedDBTestCase"                    href="/testcases/JndiBasedDBTestCase.html"/>
+        <item name="Migrating to IDatabaseTester"           href="/testcases/MigratingToIDatabaseTester.html"/>
       </item>
       <item name="Datasets"             href="/datasets.html">
         <item name="Flat XML"           href="/datasets/flatxml.html"/>
@@ -100,12 +101,12 @@
         <item name="PostgreSQL"    href="/databases/postgresql.html"/>
       </item>
       <item name="Core Components"   href="/components.html">
-        <item name="ITable &amp; Table Metadata"      href="/components/itable.html"/>
-        <item name="VerifyTableDefinition"            href="/components/verifytabledefinition.html"/>
-        <item name="IOperationListener"               href="/components/ioperationlistener.html"/>
-        <item name="IMetadataHandler"                 href="/components/imetadatahandler.html"/>
-        <item name="Assertion &amp; DbUnitAssert"      href="/components/assertion.html"/>
-        <item name="RowCountCheck"                    href="/components/rowcountcheck.html"/>
+        <item name="ITable &amp; Table Metadata"    href="/components/itable.html"/>
+        <item name="VerifyTableDefinition"          href="/components/verifytabledefinition.html"/>
+        <item name="IOperationListener"             href="/components/ioperationlistener.html"/>
+        <item name="IMetadataHandler"               href="/components/imetadatahandler.html"/>
+        <item name="Assertion &amp; DbUnitAssert"   href="/components/assertion.html"/>
+        <item name="RowCountCheck"                  href="/components/rowcountcheck.html"/>
       </item>
       <item name="Best Practices"             href="/bestpractices.html"/>
       <item name="Database Testing Concepts"  href="/intro.html"/>

--- a/src/test/java/org/dbunit/MultiDataSourcePrepAndExpectedTestCaseIT.java
+++ b/src/test/java/org/dbunit/MultiDataSourcePrepAndExpectedTestCaseIT.java
@@ -1,0 +1,326 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.dbunit.database.DatabaseConnection;
+import org.dbunit.database.IDatabaseConnection;
+import org.dbunit.operation.DatabaseOperation;
+import org.dbunit.util.fileloader.DataFileLoader;
+import org.dbunit.util.fileloader.FlatXmlDataFileLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test of {@link MultiDataSourcePrepAndExpectedTestCase} against three independent
+ * in-memory HSQLDB databases - a {@code catalog}, an {@code orders}, and an {@code inventory}
+ * data source - each with one table, standing in for an application spanning multiple databases.
+ * Inline SQL statements stand in for the application's own service layer, writing to all three
+ * databases in one {@link PrepAndExpectedTestCaseSteps#run()} call.
+ * <p>
+ * {@link MultiDataSourcePrepAndExpectedTestCaseTest} covers this class's orchestration logic
+ * (wiring, fan-out, ordering, failure aggregation) in isolation via recording/stub delegates; this
+ * class instead proves the same wrapper end to end against real connections, real cleanup, and
+ * real assertion failures.
+ *
+ * @since 3.6.0
+ */
+class MultiDataSourcePrepAndExpectedTestCaseIT
+{
+    private static final String CATALOG = "catalog";
+
+    private static final String ORDERS = "orders";
+
+    private static final String INVENTORY = "inventory";
+
+    private static final String CATALOG_PREP = "/xml/multiDataSourceCatalogPrep.xml";
+
+    private static final String CATALOG_EXPECTED = "/xml/multiDataSourceCatalogExpected.xml";
+
+    private static final String ORDERS_PREP = "/xml/multiDataSourceOrdersPrep.xml";
+
+    private static final String ORDERS_EXPECTED = "/xml/multiDataSourceOrdersExpected.xml";
+
+    private static final String ORDERS_EXPECTED_MISMATCH =
+            "/xml/multiDataSourceOrdersExpectedMismatch.xml";
+
+    private static final String INVENTORY_PREP = "/xml/multiDataSourceInventoryPrep.xml";
+
+    private static final String INVENTORY_EXPECTED = "/xml/multiDataSourceInventoryExpected.xml";
+
+    private static final String INVENTORY_EXPECTED_MISMATCH =
+            "/xml/multiDataSourceInventoryExpectedMismatch.xml";
+
+    private static final VerifyTableDefinition PRODUCT_TABLE =
+            new VerifyTableDefinition("PRODUCT", new String[0]);
+
+    // ID is database-generated: exclude it from comparison and sort on only the remaining
+    // (filtered) columns, so an unpredictable insertion/identity order can't misalign otherwise
+    // equal rows
+    private static final VerifyTableDefinition PURCHASE_ORDER_TABLE = new VerifyTableDefinition(
+            "PURCHASE_ORDER", new String[] {"ID"}, null, null, true);
+
+    private static final VerifyTableDefinition STOCK_TABLE =
+            new VerifyTableDefinition("STOCK", new String[0]);
+
+    private static final AtomicInteger RUN_COUNTER = new AtomicInteger();
+
+    private final DataFileLoader dataFileLoader = new FlatXmlDataFileLoader();
+
+    private String catalogDbName;
+
+    private String ordersDbName;
+
+    private String inventoryDbName;
+
+    private Connection catalogJdbcConnection;
+
+    private Connection ordersJdbcConnection;
+
+    private Connection inventoryJdbcConnection;
+
+    private MultiDataSourcePrepAndExpectedTestCase testCase;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        final int run = RUN_COUNTER.incrementAndGet();
+        catalogDbName = "mem:multiDsCatalog" + run;
+        ordersDbName = "mem:multiDsOrders" + run;
+        inventoryDbName = "mem:multiDsInventory" + run;
+
+        catalogJdbcConnection = HypersonicEnvironment.createJdbcConnection(catalogDbName);
+        ordersJdbcConnection = HypersonicEnvironment.createJdbcConnection(ordersDbName);
+        inventoryJdbcConnection = HypersonicEnvironment.createJdbcConnection(inventoryDbName);
+
+        createSchema(catalogJdbcConnection,
+                "CREATE TABLE PRODUCT (SKU VARCHAR(20) PRIMARY KEY, NAME VARCHAR(60),"
+                        + " UNIT_PRICE DECIMAL(10,2), UNITS_SOLD INTEGER)");
+        createSchema(ordersJdbcConnection,
+                "CREATE TABLE PURCHASE_ORDER (ID INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY"
+                        + " KEY, CUSTOMER_ID BIGINT, SKU VARCHAR(20), QUANTITY INTEGER, TOTAL"
+                        + " DECIMAL(10,2))");
+        createSchema(inventoryJdbcConnection,
+                "CREATE TABLE STOCK (SKU VARCHAR(20) PRIMARY KEY, QTY_ON_HAND INTEGER)");
+
+        testCase = MultiDataSourcePrepAndExpectedTestCase.forTesters(dataFileLoader)
+                .add(CATALOG, testerFor(catalogJdbcConnection))
+                .add(ORDERS, testerFor(ordersJdbcConnection))
+                .add(INVENTORY, testerFor(inventoryJdbcConnection));
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        closeQuietly(catalogJdbcConnection);
+        closeQuietly(ordersJdbcConnection);
+        closeQuietly(inventoryJdbcConnection);
+    }
+
+    @Test
+    void testRunTest_matchingPrepAndExpectedInEveryDataSource_doesNotThrow()
+    {
+        final Map<String, PrepAndExpectedTestData> data = new LinkedHashMap<>();
+        data.put(CATALOG, catalogData(CATALOG_EXPECTED));
+        data.put(ORDERS, ordersData(ORDERS_EXPECTED));
+        data.put(INVENTORY, inventoryData(INVENTORY_EXPECTED));
+
+        assertThatCode(() -> testCase.runTest(data, this::placeOrder))
+                .as("Matching prep and expected data in every data source must not throw.")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRunTest_expectedMismatchInTwoDataSources_throwsAssertionErrorNamingBoth()
+    {
+        final Map<String, PrepAndExpectedTestData> data = new LinkedHashMap<>();
+        data.put(CATALOG, catalogData(CATALOG_EXPECTED));
+        data.put(ORDERS, ordersData(ORDERS_EXPECTED_MISMATCH));
+        data.put(INVENTORY, inventoryData(INVENTORY_EXPECTED_MISMATCH));
+
+        final Throwable thrown = catchThrowable(() -> testCase.runTest(data, this::placeOrder));
+
+        assertThat(thrown)
+                .as("A mismatch in two data sources must surface as one"
+                        + " MultiDataSourceAssertionError, not stop at the first.")
+                .isInstanceOf(MultiDataSourceAssertionError.class);
+        assertThat(thrown.getMessage())
+                .as("The aggregate message must name both mismatched data sources.")
+                .contains(ORDERS).contains(INVENTORY);
+    }
+
+    @Test
+    void testRunTest_dataSourceOmittedFromTheRow_itsConnectionIsNeverOpened() throws Exception
+    {
+        testCase = MultiDataSourcePrepAndExpectedTestCase.forTesters(dataFileLoader)
+                .add(CATALOG, testerFor(catalogJdbcConnection))
+                .add(ORDERS, testerFor(ordersJdbcConnection))
+                .add(INVENTORY, new ThrowingDatabaseTester());
+
+        final Map<String, PrepAndExpectedTestData> data = new LinkedHashMap<>();
+        data.put(CATALOG, catalogData(CATALOG_EXPECTED));
+        data.put(ORDERS, ordersData(ORDERS_EXPECTED));
+        // inventory intentionally omitted: its tester throws if its connection is ever opened
+
+        assertThatCode(() -> testCase.runTest(data, this::placeOrder))
+                .as("A data source omitted from the data map must never have its connection"
+                        + " opened, even when opening it would throw.")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRunTest_success_cleansAndClosesEveryConnection() throws Exception
+    {
+        final Map<String, PrepAndExpectedTestData> data = new LinkedHashMap<>();
+        data.put(CATALOG, catalogData(CATALOG_EXPECTED));
+        data.put(ORDERS, ordersData(ORDERS_EXPECTED));
+        data.put(INVENTORY, inventoryData(INVENTORY_EXPECTED));
+
+        testCase.runTest(data, this::placeOrder);
+
+        assertThat(catalogJdbcConnection.isClosed())
+                .as("catalog's connection must be closed after a successful runTest(...).")
+                .isTrue();
+        assertThat(ordersJdbcConnection.isClosed())
+                .as("orders' connection must be closed after a successful runTest(...).")
+                .isTrue();
+        assertThat(inventoryJdbcConnection.isClosed())
+                .as("inventory's connection must be closed after a successful runTest(...).")
+                .isTrue();
+
+        assertRowCount(catalogDbName, "PRODUCT", 0);
+        assertRowCount(ordersDbName, "PURCHASE_ORDER", 0);
+        assertRowCount(inventoryDbName, "STOCK", 0);
+    }
+
+    /**
+     * Stands in for the application's service layer: one call writing to all three databases,
+     * via plain JDBC rather than any dbUnit type.
+     */
+    private Object placeOrder() throws Exception
+    {
+        try (Statement statement = catalogJdbcConnection.createStatement())
+        {
+            statement.executeUpdate(
+                    "UPDATE PRODUCT SET UNITS_SOLD = UNITS_SOLD + 3 WHERE SKU = 'WIDGET-1'");
+        }
+        try (Statement statement = ordersJdbcConnection.createStatement())
+        {
+            statement.executeUpdate("INSERT INTO PURCHASE_ORDER (CUSTOMER_ID, SKU, QUANTITY,"
+                    + " TOTAL) VALUES (42, 'WIDGET-1', 3, 29.97)");
+        }
+        try (Statement statement = inventoryJdbcConnection.createStatement())
+        {
+            statement.executeUpdate(
+                    "UPDATE STOCK SET QTY_ON_HAND = QTY_ON_HAND - 3 WHERE SKU = 'WIDGET-1'");
+        }
+        return null;
+    }
+
+    private static PrepAndExpectedTestData catalogData(final String expectedFile)
+    {
+        return new PrepAndExpectedTestData(new VerifyTableDefinition[] {PRODUCT_TABLE},
+                new String[] {CATALOG_PREP}, new String[] {expectedFile});
+    }
+
+    private static PrepAndExpectedTestData ordersData(final String expectedFile)
+    {
+        return new PrepAndExpectedTestData(new VerifyTableDefinition[] {PURCHASE_ORDER_TABLE},
+                new String[] {ORDERS_PREP}, new String[] {expectedFile});
+    }
+
+    private static PrepAndExpectedTestData inventoryData(final String expectedFile)
+    {
+        return new PrepAndExpectedTestData(new VerifyTableDefinition[] {STOCK_TABLE},
+                new String[] {INVENTORY_PREP}, new String[] {expectedFile});
+    }
+
+    private static void createSchema(final Connection connection, final String ddl)
+            throws Exception
+    {
+        DdlExecutor.executeSql(connection, ddl);
+    }
+
+    private static IDatabaseTester testerFor(final Connection connection) throws Exception
+    {
+        final IDatabaseConnection databaseConnection = new DatabaseConnection(connection);
+        final IDatabaseTester tester = new DefaultDatabaseTester(databaseConnection);
+        tester.setTearDownOperation(DatabaseOperation.DELETE_ALL);
+        return tester;
+    }
+
+    private static void assertRowCount(final String dbName, final String tableName,
+            final int expectedRows) throws Exception
+    {
+        try (Connection connection = HypersonicEnvironment.createJdbcConnection(dbName);
+                Statement statement = connection.createStatement();
+                ResultSet resultSet =
+                        statement.executeQuery("SELECT COUNT(*) FROM " + tableName))
+        {
+            resultSet.next();
+            assertThat(resultSet.getInt(1))
+                    .as("Table " + tableName + " must be empty; a successful runTest(...) must"
+                            + " have cleaned it up.")
+                    .isEqualTo(expectedRows);
+        }
+    }
+
+    private static void closeQuietly(final Connection connection)
+    {
+        try
+        {
+            if (connection != null && !connection.isClosed())
+            {
+                connection.close();
+            }
+        } catch (final SQLException e)
+        {
+            // best-effort cleanup between tests; a connection cleanupData() already closed is
+            // expected to land here
+        }
+    }
+
+    /**
+     * An {@link IDatabaseTester} that throws if its connection is ever requested, for proving a
+     * data source omitted from a {@code runTest(...)} data map is never touched.
+     */
+    private static final class ThrowingDatabaseTester extends AbstractDatabaseTester
+    {
+        @Override
+        public IDatabaseConnection getConnection()
+        {
+            throw new AssertionError("This data source's connection must never be opened when"
+                    + " it is omitted from the runTest(...) data map.");
+        }
+    }
+}

--- a/src/test/java/org/dbunit/MultiDataSourcePrepAndExpectedTestCaseTest.java
+++ b/src/test/java/org/dbunit/MultiDataSourcePrepAndExpectedTestCaseTest.java
@@ -1,0 +1,789 @@
+/*
+ *
+ * The DbUnit Database Testing Framework
+ * Copyright (C)2002-2026, DbUnit.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+package org.dbunit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.dbunit.assertion.DbComparisonFailure;
+import org.dbunit.database.MockDatabaseConnection;
+import org.dbunit.dataset.IDataSet;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link MultiDataSourcePrepAndExpectedTestCase}, using recording/stub
+ * {@link PrepAndExpectedTestCase} delegates instead of real database connections - the
+ * orchestration this class adds (wiring, fan-out, ordering, and failure aggregation) does not
+ * depend on any one delegate's own database behavior, which is already covered at the
+ * {@link DefaultPrepAndExpectedTestCase} level. {@link MultiDataSourcePrepAndExpectedTestCaseIT}
+ * covers the same class end to end against real databases.
+ *
+ * @since 3.6.0
+ */
+class MultiDataSourcePrepAndExpectedTestCaseTest
+{
+    // ---- construction / assembly ----
+
+    @Test
+    void testFrom_thenAdd_wiresDataSourcesInCallOrder()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        assertThat(testCase.getDataSourceNames())
+                .as("from(...).add(...) must wire the data sources in call order.")
+                .containsExactly("catalog", "orders");
+    }
+
+    @Test
+    void testConstructor_linkedHashMap_wiresInMapIterationOrder()
+    {
+        final Map<String, PrepAndExpectedTestCase> seed = new LinkedHashMap<>();
+        seed.put("orders", new RecordingTestCase("orders", new ArrayList<>()));
+        seed.put("catalog", new RecordingTestCase("catalog", new ArrayList<>()));
+
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                new MultiDataSourcePrepAndExpectedTestCase(seed);
+
+        assertThat(testCase.getDataSourceNames())
+                .as("The Map constructor must wire data sources in the given map's iteration"
+                        + " order.")
+                .containsExactly("orders", "catalog");
+    }
+
+    @Test
+    void testConstructor_mutatingTheSourceMapAfterwards_doesNotAffectTheWrapper()
+    {
+        final Map<String, PrepAndExpectedTestCase> seed = new LinkedHashMap<>();
+        seed.put("catalog", new RecordingTestCase("catalog", new ArrayList<>()));
+
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                new MultiDataSourcePrepAndExpectedTestCase(seed);
+        seed.put("orders", new RecordingTestCase("orders", new ArrayList<>()));
+
+        assertThat(testCase.getDataSourceNames())
+                .as("The constructor must defensively copy the source map, so mutating it"
+                        + " afterward does not affect this instance.")
+                .containsExactly("catalog");
+    }
+
+    @Test
+    void testConstructor_nullMapOrNullOrBlankKeyOrNullDelegate_throws()
+    {
+        assertThatThrownBy(() -> new MultiDataSourcePrepAndExpectedTestCase(null))
+                .as("A null seed map must throw.").isInstanceOf(IllegalArgumentException.class);
+
+        final Map<String, PrepAndExpectedTestCase> nullKey = new LinkedHashMap<>();
+        nullKey.put(null, new RecordingTestCase("x", new ArrayList<>()));
+        assertThatThrownBy(() -> new MultiDataSourcePrepAndExpectedTestCase(nullKey))
+                .as("A null data source name in the seed map must throw.")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final Map<String, PrepAndExpectedTestCase> blankKey = new LinkedHashMap<>();
+        blankKey.put("   ", new RecordingTestCase("x", new ArrayList<>()));
+        assertThatThrownBy(() -> new MultiDataSourcePrepAndExpectedTestCase(blankKey))
+                .as("A blank data source name in the seed map must throw.")
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final Map<String, PrepAndExpectedTestCase> nullDelegate = new LinkedHashMap<>();
+        nullDelegate.put("catalog", null);
+        assertThatThrownBy(() -> new MultiDataSourcePrepAndExpectedTestCase(nullDelegate))
+                .as("A null delegate in the seed map must throw.")
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testAdd_duplicateDataSourceName_throwsIllegalArgumentException()
+    {
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", new RecordingTestCase("catalog", new ArrayList<>()));
+
+        assertThatThrownBy(() -> testCase.add("catalog",
+                new RecordingTestCase("catalog-2", new ArrayList<>())))
+                .as("Adding a second delegate under an already-wired data source name must"
+                        + " throw.")
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testAdd_afterFirstPreTest_throwsIllegalStateException() throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+
+        testCase.preTest(map("catalog", someData()));
+
+        assertThatThrownBy(
+                () -> testCase.add("orders", new RecordingTestCase("orders", new ArrayList<>())))
+                .as("add(...) after the wiring is frozen by the first preTest(...) call must"
+                        + " throw.")
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testPreTest_firstCallFailsValidation_wiringStaysUnfrozenSoAddStillWorks() throws Exception
+    {
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                new MultiDataSourcePrepAndExpectedTestCase();
+
+        assertThatThrownBy(() -> testCase.preTest(map("catalog", someData())))
+                .as("preTest on an instance with nothing wired yet must throw.")
+                .isInstanceOf(IllegalStateException.class);
+
+        testCase.add("catalog", new RecordingTestCase("catalog", new ArrayList<>()));
+
+        assertThat(testCase.getDataSourceNames())
+                .as("A failed first preTest call - before any delegate was ever wired or"
+                        + " touched - must not have frozen the wiring, so add(...) afterward"
+                        + " must still work.")
+                .containsExactly("catalog");
+    }
+
+    @Test
+    void testAddTester_onInstanceNotCreatedViaForTesters_throwsIllegalStateException()
+    {
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                new MultiDataSourcePrepAndExpectedTestCase();
+        final IDatabaseTester tester = new DefaultDatabaseTester(new MockDatabaseConnection());
+
+        assertThatThrownBy(() -> testCase.add("catalog", tester))
+                .as("add(String, IDatabaseTester) on an instance not created via one of the"
+                        + " forTesters(...) factories must throw.")
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testPreTest_wiredViaMapOf_stillRunsEveryDataSource() throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        // a HashMap's iteration order is unspecified, standing in here for a Java 9+ caller's
+        // Map.of(...) - this module's own sources build at Java 8 (pom.xml release=8), so this
+        // test cannot literally call Map.of(...) itself
+        final Map<String, PrepAndExpectedTestCase> unordered = new HashMap<>();
+        unordered.put("catalog", catalog);
+        unordered.put("orders", orders);
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                new MultiDataSourcePrepAndExpectedTestCase(unordered);
+
+        testCase.preTest(map("catalog", someData(), "orders", someData()));
+        testCase.postTest(true);
+
+        assertThat(catalog.touched)
+                .as("Every wired data source must run regardless of the source map's"
+                        + " (unspecified) iteration order.")
+                .isTrue();
+        assertThat(orders.touched)
+                .as("Every wired data source must run regardless of the source map's"
+                        + " (unspecified) iteration order.")
+                .isTrue();
+    }
+
+    @Test
+    void testPreTest_zeroDataSources_throwsIllegalStateException()
+    {
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                new MultiDataSourcePrepAndExpectedTestCase();
+
+        assertThatThrownBy(() -> testCase.preTest(new LinkedHashMap<>()))
+                .as("preTest(...) with zero data sources wired must throw.")
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    // ---- lifecycle ----
+
+    @Test
+    void testPreTest_mapHasUnknownDataSourceKey_throwsBeforeAnyDelegateTouched()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+
+        assertThatThrownBy(
+                () -> testCase.preTest(map("catalog", someData(), "bogus", someData())))
+                .as("An unknown data source key must throw.")
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(catalog.touched)
+                .as("The wired (known) delegate must not be touched when the same call also"
+                        + " contains an unknown data source key.")
+                .isFalse();
+    }
+
+    @Test
+    void testPreTest_dataSourceMappedToNull_throwsBeforeAnyDelegateTouched()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        assertThatThrownBy(
+                () -> testCase.preTest(map("catalog", someData(), "orders", null)))
+                .as("A wired data source explicitly mapped to null must throw, not be silently"
+                        + " skipped like an absent key or NONE would be.")
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(catalog.touched)
+                .as("No delegate may be touched when the data map is rejected.")
+                .isFalse();
+    }
+
+    @Test
+    void testPreTest_dataSourceAbsentFromMap_thatDelegateIsNeverTouched() throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        testCase.preTest(map("catalog", someData()));
+
+        assertThat(catalog.touched).as("A data source present in the data map must be touched.")
+                .isTrue();
+        assertThat(orders.touched)
+                .as("A wired data source absent from the data map must never be touched.")
+                .isFalse();
+    }
+
+    @Test
+    void testPreTest_dataSourceMappedToNONE_thatDelegateIsNeverTouched() throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        testCase.preTest(map("catalog", someData(), "orders", PrepAndExpectedTestData.NONE));
+
+        assertThat(orders.touched)
+                .as("A data source mapped to the exact NONE instance must never be touched.")
+                .isFalse();
+    }
+
+    @Test
+    void testPreTest_dataSourceMappedToAnEmptyButDistinctInstance_thatDelegateIsStillTouched()
+            throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+        final PrepAndExpectedTestData emptyButDistinct = someData();
+        assertThat(emptyButDistinct)
+                .as("Sanity check: the empty bundle must be content-equal to NONE for this test"
+                        + " to actually prove the == check rather than the equals() contract.")
+                .isEqualTo(PrepAndExpectedTestData.NONE);
+
+        testCase.preTest(map("catalog", emptyButDistinct));
+
+        assertThat(catalog.touched)
+                .as("A data source mapped to a content-equal-but-distinct empty bundle must"
+                        + " still be touched; only the literal NONE instance means skip.")
+                .isTrue();
+    }
+
+    @Test
+    void testPreTest_threeInvolvedDataSources_setsUpEachInDeclaredOrder() throws Exception
+    {
+        final List<String> callLog = new ArrayList<>();
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", callLog);
+        final RecordingTestCase orders = new RecordingTestCase("orders", callLog);
+        final RecordingTestCase inventory = new RecordingTestCase("inventory", callLog);
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders).add("inventory", inventory);
+
+        testCase.preTest(map("catalog", someData(), "orders", someData(), "inventory",
+                someData()));
+
+        assertThat(callLog).as("The three involved data sources must be set up in declared"
+                + " order.")
+                .containsExactly("catalog:preTest", "orders:preTest", "inventory:preTest");
+    }
+
+    @Test
+    void testPreTest_laterDataSourceSetupThrows_rollsBackEarlierAndFailingDelegateViaPostTestFalse()
+    {
+        final List<String> callLog = new ArrayList<>();
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", callLog);
+        final RecordingTestCase orders = new RecordingTestCase("orders", callLog);
+        orders.failOnPreTest(new RuntimeException("orders setup failed"));
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        assertThatThrownBy(
+                () -> testCase.preTest(map("catalog", someData(), "orders", someData())))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(callLog)
+                .as("Every data source set up so far - the earlier one, and the one whose own"
+                        + " preTest just failed - must be rolled back via postTest(false), in"
+                        + " reverse order, not a bare cleanupData().")
+                .containsExactly("catalog:preTest", "orders:preTest", "orders:postTest(false)",
+                        "catalog:postTest(false)");
+    }
+
+    @Test
+    void testPreTest_laterDataSourceSetupThrows_rethrowsTheSetupFailureItselfWithRollbackSuppressed()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RuntimeException rollbackFailure = new RuntimeException("catalog rollback failed");
+        catalog.failOnPostTest(rollbackFailure);
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final RuntimeException setupFailure = new RuntimeException("orders setup failed");
+        orders.failOnPreTest(setupFailure);
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        final Throwable thrown = catchThrowable(
+                () -> testCase.preTest(map("catalog", someData(), "orders", someData())));
+
+        assertThat(thrown).as("preTest(...) must rethrow the real setup failure itself, not a"
+                + " wrapper.").isSameAs(setupFailure);
+        assertThat(thrown.getSuppressed())
+                .as("A rollback failure must be attached as suppressed on the setup failure.")
+                .containsExactly(rollbackFailure);
+    }
+
+    @Test
+    void testPreTest_rollbackFailureIsTheSameInstanceAsTheSetupFailure_skipsItButStillSuppressesADistinctOne()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RuntimeException catalogRollbackFailure =
+                new RuntimeException("catalog rollback failed");
+        catalog.failOnPostTest(catalogRollbackFailure);
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final RuntimeException setupFailure = new RuntimeException("orders setup failed");
+        orders.failOnPreTest(setupFailure);
+        orders.failOnPostTest(setupFailure);
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+
+        final Throwable thrown = catchThrowable(
+                () -> testCase.preTest(map("catalog", someData(), "orders", someData())));
+
+        assertThat(thrown).as("preTest(...) must still rethrow the real setup failure itself.")
+                .isSameAs(setupFailure);
+        assertThat(thrown.getSuppressed())
+                .as("orders' own rollback failure is the exact same instance as the setup"
+                        + " failure and must be skipped rather than self-suppressed, but"
+                        + " catalog's distinct rollback failure must still be attached - proving"
+                        + " the self-suppression guard does not stop the rollback loop early.")
+                .containsExactly(catalogRollbackFailure);
+    }
+
+    @Test
+    void testRunTest_threeDataSources_runsTestStepsExactlyOnce() throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final RecordingTestCase inventory = new RecordingTestCase("inventory", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders).add("inventory", inventory);
+        final AtomicInteger stepRunCount = new AtomicInteger();
+
+        testCase.runTest(
+                map("catalog", someData(), "orders", someData(), "inventory", someData()),
+                () -> stepRunCount.incrementAndGet());
+
+        assertThat(stepRunCount).as("The test steps must run exactly once.").hasValue(1);
+    }
+
+    @Test
+    void testRunTest_testStepsThrow_rethrowsTheStepExceptionItselfNotAWrapper()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+        final RuntimeException stepFailure = new RuntimeException("step failed");
+
+        final Throwable thrown = catchThrowable(() -> testCase.runTest(map("catalog", someData()),
+                () -> {
+                    throw stepFailure;
+                }));
+
+        assertThat(thrown).as("runTest(...) must rethrow the step exception itself, not a"
+                + " wrapper.").isSameAs(stepFailure);
+    }
+
+    @Test
+    void testRunTest_testStepsThrow_tearsDownEveryInvolvedDataSourceWithFailuresSuppressedOnStepException()
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RuntimeException catalogTeardownFailure =
+                new RuntimeException("catalog teardown failed");
+        catalog.failOnPostTest(catalogTeardownFailure);
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+        final RuntimeException stepFailure = new RuntimeException("step failed");
+
+        final Throwable thrown = catchThrowable(() -> testCase
+                .runTest(map("catalog", someData(), "orders", someData()), () -> {
+                    throw stepFailure;
+                }));
+
+        assertThat(thrown).isSameAs(stepFailure);
+        assertThat(thrown.getSuppressed())
+                .as("Every involved data source must be torn down, with each teardown failure"
+                        + " suppressed onto the step exception.")
+                .containsExactly(catalogTeardownFailure);
+        assertThat(orders.lastPostTestVerifyData)
+                .as("Teardown after a step failure must call postTest(false) - not verify - on"
+                        + " every involved data source.")
+                .isFalse();
+    }
+
+    @Test
+    void testRunTest_stepFailureIsTheSameInstanceAsATeardownFailure_stillRethrowsItWithoutSelfSuppressionError()
+    {
+        final RuntimeException sharedFailure = new RuntimeException("shared failure instance");
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        catalog.failOnPostTest(sharedFailure);
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+
+        final Throwable thrown = catchThrowable(() -> testCase.runTest(map("catalog", someData()),
+                () -> {
+                    throw sharedFailure;
+                }));
+
+        assertThat(thrown)
+                .as("The original failure must still be rethrown as-is even when a delegate's"
+                        + " own teardown failure happens to be the exact same instance -"
+                        + " addSuppressed() would otherwise throw for self-suppression and mask"
+                        + " it.")
+                .isSameAs(sharedFailure);
+        assertThat(thrown.getSuppressed())
+                .as("A teardown failure that is the primary failure itself must not be added as"
+                        + " suppressed onto itself.")
+                .isEmpty();
+    }
+
+    @Test
+    void testPostTest_verifyTrueAndOneDataSourceFails_throwsAssertionErrorWithThatFailureAsCause()
+            throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final DbComparisonFailure verifyFailure =
+                new DbComparisonFailure("reason", "expected", "actual");
+        catalog.failOnPostTest(verifyFailure);
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+        testCase.preTest(map("catalog", someData()));
+
+        final Throwable thrown = catchThrowable(() -> testCase.postTest(true));
+
+        assertThat(thrown).as("A single involved data source's postTest failure must surface as"
+                + " a MultiDataSourceAssertionError.")
+                .isInstanceOf(MultiDataSourceAssertionError.class);
+        assertThat(thrown.getCause())
+                .as("That single failure must be this failure's cause, unwrapped, one Caused by"
+                        + " hop down.")
+                .isSameAs(verifyFailure);
+    }
+
+    @Test
+    void testPostTest_verifyTrueAndFailureIsNotAnAssertionError_labelsThePhaseGenericallyAsPostTest()
+            throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        catalog.failOnPostTest(new Exception("a checked failure that is not an AssertionError"));
+        final MultiDataSourcePrepAndExpectedTestCase testCase =
+                MultiDataSourcePrepAndExpectedTestCase.from("catalog", catalog);
+        testCase.preTest(map("catalog", someData()));
+
+        final Throwable aggregate = catchThrowable(() -> testCase.postTest(true));
+
+        assertThat(aggregate.getMessage())
+                .as("A postTest(true) failure that is not an AssertionError could equally have"
+                        + " come from verifyData() (e.g. a checked DataSetException) or"
+                        + " cleanupData(); it must not be confidently mislabelled as"
+                        + " cleanupData.")
+                .contains("catalog (postTest)");
+    }
+
+    @Test
+    void testPostTest_verifyTrueAndTwoDataSourcesFail_aggregateNamesBothFirstAsCauseRestSuppressed()
+            throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final RecordingTestCase inventory = new RecordingTestCase("inventory", new ArrayList<>());
+        final DbComparisonFailure ordersFailure =
+                new DbComparisonFailure("reason", "expected", "actual");
+        orders.failOnPostTest(ordersFailure);
+        final RuntimeException inventoryFailure = new RuntimeException("inventory cleanup failed");
+        inventory.failOnPostTest(inventoryFailure);
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders).add("inventory", inventory);
+        testCase.preTest(map("catalog", someData(), "orders", someData(), "inventory",
+                someData()));
+
+        final Throwable aggregate = catchThrowable(() -> testCase.postTest(true));
+
+        assertThat(aggregate)
+                .as("Both postTest failures must be aggregated into one"
+                        + " MultiDataSourceAssertionError.")
+                .isInstanceOf(MultiDataSourceAssertionError.class);
+        assertThat(aggregate.getMessage())
+                .as("The aggregate message must name both failing data sources.")
+                .contains("orders").contains("inventory");
+        assertThat(aggregate.getCause())
+                .as("The first-declared failing data source's own failure must be the cause,"
+                        + " unwrapped, one Caused by hop down.")
+                .isSameAs(ordersFailure);
+        assertThat(aggregate.getSuppressed())
+                .as("The second-declared failing data source's failure must be attached as"
+                        + " suppressed.")
+                .hasSize(1);
+        assertThat(aggregate.getSuppressed()[0].getCause())
+                .as("The suppressed entry must carry the real failure as its own cause, so it"
+                        + " reads without unwrapping further.")
+                .isSameAs(inventoryFailure);
+    }
+
+    @Test
+    void testPostTest_reverseOrderTeardown_tearsDownLastDeclaredInvolvedDataSourceFirst()
+            throws Exception
+    {
+        final List<String> callLog = new ArrayList<>();
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", callLog);
+        final RecordingTestCase orders = new RecordingTestCase("orders", callLog);
+        final RecordingTestCase inventory = new RecordingTestCase("inventory", callLog);
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders).add("inventory", inventory);
+        testCase.preTest(map("catalog", someData(), "orders", someData(), "inventory",
+                someData()));
+        callLog.clear();
+
+        testCase.postTest(true);
+
+        assertThat(callLog)
+                .as("Teardown must run in reverse declared order: inventory, then orders, then"
+                        + " catalog.")
+                .containsExactly("inventory:postTest(true)", "orders:postTest(true)",
+                        "catalog:postTest(true)");
+    }
+
+    @Test
+    void testPostTest_verifyFalse_discardsRowCountBaselineOnEachInvolvedDelegate()
+            throws Exception
+    {
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", new ArrayList<>());
+        final RecordingTestCase orders = new RecordingTestCase("orders", new ArrayList<>());
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders);
+        testCase.preTest(map("catalog", someData(), "orders", someData()));
+
+        testCase.postTest(false);
+
+        assertThat(catalog.lastPostTestVerifyData)
+                .as("postTest(false) must call postTest(false) on every involved delegate - what"
+                        + " makes each delegate discard its own row count baseline instead of"
+                        + " verifying.")
+                .isFalse();
+        assertThat(orders.lastPostTestVerifyData).isFalse();
+    }
+
+    @Test
+    void testPostTest_oneDelegateCleanupThrows_stillTearsDownTheOthersAndAggregates()
+            throws Exception
+    {
+        final List<String> callLog = new ArrayList<>();
+        final RecordingTestCase catalog = new RecordingTestCase("catalog", callLog);
+        final RecordingTestCase orders = new RecordingTestCase("orders", callLog);
+        orders.failOnPostTest(new RuntimeException("orders cleanup failed"));
+        final RecordingTestCase inventory = new RecordingTestCase("inventory", callLog);
+        final MultiDataSourcePrepAndExpectedTestCase testCase = MultiDataSourcePrepAndExpectedTestCase
+                .from("catalog", catalog).add("orders", orders).add("inventory", inventory);
+        testCase.preTest(map("catalog", someData(), "orders", someData(), "inventory",
+                someData()));
+        callLog.clear();
+
+        final Throwable aggregate = catchThrowable(() -> testCase.postTest(true));
+
+        assertThat(aggregate).isInstanceOf(MultiDataSourceAssertionError.class);
+        assertThat(callLog)
+                .as("catalog and inventory must still be torn down, in reverse declared order,"
+                        + " even though orders failed in between.")
+                .containsExactly("inventory:postTest(true)", "orders:postTest(true)",
+                        "catalog:postTest(true)");
+    }
+
+    private static PrepAndExpectedTestData someData()
+    {
+        return new PrepAndExpectedTestData(new VerifyTableDefinition[0], new String[0],
+                new String[0]);
+    }
+
+    private static Map<String, PrepAndExpectedTestData> map(final String name,
+            final PrepAndExpectedTestData data)
+    {
+        final Map<String, PrepAndExpectedTestData> result = new LinkedHashMap<>();
+        result.put(name, data);
+        return result;
+    }
+
+    private static Map<String, PrepAndExpectedTestData> map(final String name1,
+            final PrepAndExpectedTestData data1, final String name2,
+            final PrepAndExpectedTestData data2)
+    {
+        final Map<String, PrepAndExpectedTestData> result = map(name1, data1);
+        result.put(name2, data2);
+        return result;
+    }
+
+    private static Map<String, PrepAndExpectedTestData> map(final String name1,
+            final PrepAndExpectedTestData data1, final String name2,
+            final PrepAndExpectedTestData data2, final String name3,
+            final PrepAndExpectedTestData data3)
+    {
+        final Map<String, PrepAndExpectedTestData> result = map(name1, data1, name2, data2);
+        result.put(name3, data3);
+        return result;
+    }
+
+    /**
+     * Records the exact {@code preTest}/{@code postTest(boolean)} calls and their order via a
+     * shared call log, and can be told to throw on demand from either.
+     */
+    private static final class RecordingTestCase implements PrepAndExpectedTestCase
+    {
+        private final String name;
+
+        private final List<String> callLog;
+
+        private boolean touched;
+
+        private Boolean lastPostTestVerifyData;
+
+        private Throwable preTestFailure;
+
+        private Throwable postTestFailure;
+
+        RecordingTestCase(final String name, final List<String> callLog)
+        {
+            this.name = name;
+            this.callLog = callLog;
+        }
+
+        void failOnPreTest(final Throwable failure)
+        {
+            preTestFailure = failure;
+        }
+
+        void failOnPostTest(final Throwable failure)
+        {
+            postTestFailure = failure;
+        }
+
+        private static void throwIfSet(final Throwable failure) throws Exception
+        {
+            if (failure == null)
+            {
+                return;
+            }
+            if (failure instanceof RuntimeException)
+            {
+                throw (RuntimeException) failure;
+            }
+            if (failure instanceof Error)
+            {
+                throw (Error) failure;
+            }
+            throw (Exception) failure;
+        }
+
+        @Override
+        public void configureTest(final VerifyTableDefinition[] verifyTableDefinitions,
+                final String[] prepDataFiles, final String[] expectedDataFiles)
+        {
+        }
+
+        @Override
+        public void preTest()
+        {
+        }
+
+        @Override
+        public void preTest(final VerifyTableDefinition[] verifyTables,
+                final String[] prepDataFiles, final String[] expectedDataFiles) throws Exception
+        {
+            touched = true;
+            callLog.add(name + ":preTest");
+            throwIfSet(preTestFailure);
+        }
+
+        @Override
+        public Object runTest(final VerifyTableDefinition[] verifyTables,
+                final String[] prepDataFiles, final String[] expectedDataFiles,
+                final PrepAndExpectedTestCaseSteps testSteps)
+        {
+            return null;
+        }
+
+        @Override
+        public void postTest()
+        {
+        }
+
+        @Override
+        public void postTest(final boolean verifyData) throws Exception
+        {
+            touched = true;
+            lastPostTestVerifyData = verifyData;
+            callLog.add(name + ":postTest(" + verifyData + ")");
+            throwIfSet(postTestFailure);
+        }
+
+        @Override
+        public void verifyData()
+        {
+        }
+
+        @Override
+        public void cleanupData()
+        {
+        }
+
+        @Override
+        public IDataSet getPrepDataset()
+        {
+            return null;
+        }
+
+        @Override
+        public IDataSet getExpectedDataset()
+        {
+            return null;
+        }
+    }
+}

--- a/src/test/resources/xml/multiDataSourceCatalogExpected.xml
+++ b/src/test/resources/xml/multiDataSourceCatalogExpected.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <PRODUCT SKU='WIDGET-1' NAME='Widget' UNIT_PRICE='9.99' UNITS_SOLD='7'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceCatalogPrep.xml
+++ b/src/test/resources/xml/multiDataSourceCatalogPrep.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <PRODUCT SKU='WIDGET-1' NAME='Widget' UNIT_PRICE='9.99' UNITS_SOLD='4'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceInventoryExpected.xml
+++ b/src/test/resources/xml/multiDataSourceInventoryExpected.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <STOCK SKU='WIDGET-1' QTY_ON_HAND='97'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceInventoryExpectedMismatch.xml
+++ b/src/test/resources/xml/multiDataSourceInventoryExpectedMismatch.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <STOCK SKU='WIDGET-1' QTY_ON_HAND='1'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceInventoryPrep.xml
+++ b/src/test/resources/xml/multiDataSourceInventoryPrep.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <STOCK SKU='WIDGET-1' QTY_ON_HAND='100'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceOrdersExpected.xml
+++ b/src/test/resources/xml/multiDataSourceOrdersExpected.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <PURCHASE_ORDER CUSTOMER_ID='42' SKU='WIDGET-1' QUANTITY='3' TOTAL='29.97'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceOrdersExpectedMismatch.xml
+++ b/src/test/resources/xml/multiDataSourceOrdersExpectedMismatch.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <PURCHASE_ORDER CUSTOMER_ID='42' SKU='WIDGET-1' QUANTITY='999' TOTAL='9999.00'/>
+</dataset>

--- a/src/test/resources/xml/multiDataSourceOrdersPrep.xml
+++ b/src/test/resources/xml/multiDataSourceOrdersPrep.xml
@@ -1,0 +1,3 @@
+<dataset>
+    <PURCHASE_ORDER/>
+</dataset>


### PR DESCRIPTION
…-data-source tests

A test exercising code that spans two or more databases has no way to prep and verify tables in each database around one run of the code under test. It must hand-drive a second IDatabaseTester and reimplement the setup/verify/cleanup/connection bookkeeping itself - easy to get subtly wrong, e.g. a failed setup's rollback must call postTest(false), not a bare cleanupData(), or the delegate's own row count check fires against a half-set-up, unknown-state database and buries the real cause.

MultiDataSourcePrepAndExpectedTestCase wraps an ordered {dataSourceName -> PrepAndExpectedTestCase} map of delegates - normally one DefaultPrepAndExpectedTestCase per data source - and runs the same prep -> steps -> verify -> cleanup lifecycle, fanning setup and teardown out to every delegate through its own preTest()/postTest(boolean) while running the test steps exactly once:

* Construction: a Map constructor, from(name, testCase), the forTesters(loader[, closeConnectionAfterTest][, map]) factories, and fluent add(name, testCase)/add(name, tester)/addAll(map), each returning this so calls chain; the wiring freezes on the first preTest(map)/runTest(map, steps) call.
* preTest(map) sets up every involved data source - present in the data map and not mapped to PrepAndExpectedTestData.NONE - in declared order; an absent or NONE-mapped data source sits that run out entirely, its connection never opened. A setup failure rolls back every already-set-up delegate via postTest(false) in reverse, suppressing rollback failures onto the real one, which is rethrown as-is.
* postTest(boolean) verifies and cleans up every involved delegate in reverse declared order even after an earlier one fails, aggregating every failure into the new MultiDataSourceAssertionError instead of stopping at the first.
* runTest(map, steps) mirrors DefaultPrepAndExpectedTestCase.runTest: preTest, the steps once, then postTest; a step failure tears down every involved delegate with postTest(false) and is rethrown as-is, teardown failures suppressed onto it.

MultiDataSourceAssertionError extends AssertionError - not a checked exception, not org.opentest4j.MultipleFailuresError - so it stays usable from a non-JUnit delegate and assertThrows(AssertionError.class, ...) keeps working for one failure or several: the first failure becomes its cause, surfacing the real DbComparisonFailure one Caused by: hop down, and the rest are added as suppressed, each labelled with its data source name and phase.

The wrapper does not implement PrepAndExpectedTestCase itself - that interface's singular accessors have no honest answer for N data sources - and drives each delegate only through its own public preTest/postTest, so DefaultPrepAndExpectedTestCase needs no edit.

MultiDataSourcePrepAndExpectedTestCaseTest covers the orchestration with recording/stub delegates; MultiDataSourcePrepAndExpectedTestCaseIT covers the same wrapper against three independent in-memory HSQLDB databases. The annotation-driven equivalent is deliberately out of scope, tracked separately as issue 969.

Refs: 968


Claude-Session: https://claude.ai/code/session_01CdxCn6DZ1zmkUVkcqWHFh2

## Summary by Sourcery

Add coordinated multi-data-source preparation and verification so tests can exercise code spanning multiple databases with one lifecycle and shared test execution.

New Features:
- Add MultiDataSourcePrepAndExpectedTestCase for coordinating preparation, execution, verification, and cleanup across multiple named data sources in one test run.
- Add MultiDataSourceAssertionError to preserve the primary failure while aggregating and labelling failures from other data sources.

Enhancements:
- Support ordered data-source wiring, per-run omission or NONE skipping, rollback on setup failures, reverse-order teardown, and failure suppression without requiring changes to existing delegate test cases.

Documentation:
- Document the multi-data-source test case and add it to the test integration documentation navigation.

Tests:
- Add unit and HSQLDB integration coverage for multi-data-source lifecycle orchestration, ordering, failure handling, selective participation, cleanup, and aggregated assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for preparing, running, verifying, and cleaning up tests across multiple data sources.
  - Data sources are processed in a defined order, with reverse-order cleanup and rollback when setup fails.
  - Test steps run once, while omitted data sources can be skipped.
  - Failures from multiple data sources are combined into a clearly labeled assertion error.

- **Documentation**
  - Added usage guidance, examples, navigation, and release notes for multi-data-source test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->